### PR TITLE
Fix for a potentially nasty resource consumption bug

### DIFF
--- a/shavar/parse.py
+++ b/shavar/parse.py
@@ -5,6 +5,9 @@ from shavar.types import Chunk, ChunkList, Downloads, DownloadsListInfo
 def parse_downloads(request):
     parsed = Downloads()
 
+    limit = request.registry.settings.get("shavar.max_downloads_chunks",
+                                          10000)
+
     for lineno, line in enumerate(request.body_file):
         line = line.strip()
 
@@ -26,7 +29,7 @@ def parse_downloads(request):
             continue
 
         lname, chunklist = line.split(";", 2)
-        info = DownloadsListInfo(lname)
+        info = DownloadsListInfo(lname, limit=limit)
 
         chunks = chunklist.split(":")
         # Check for MAC

--- a/shavar/tests/base.py
+++ b/shavar/tests/base.py
@@ -73,7 +73,7 @@ def dummy(body, path="/downloads", **kwargs):
 def test_file(fname):
     return os.path.join(os.path.dirname(__file__), fname)
 
-# Ensure that test runners done think this is an actual testcase.
+# Ensure that test runners don't think this is an actual testcase.
 test_file.__test__ = False
 
 

--- a/shavar/tests/test_parse.py
+++ b/shavar/tests/test_parse.py
@@ -1,22 +1,26 @@
 import hashlib
 import StringIO
-import unittest
 
 from shavar.parse import parse_downloads, parse_gethash, parse_file_source
-from shavar.types import ChunkList, Chunk, Downloads, DownloadsListInfo
+from shavar.types import (
+    Chunk,
+    ChunkList,
+    Downloads,
+    DownloadsListInfo,
+    LimitExceededError)
 from shavar.tests.base import (
     dummy,
     hashes,
-    test_file)
+    test_file,
+    ShavarTestCase)
 
 
-class ParseTest(unittest.TestCase):
+class ParseTest(ShavarTestCase):
+
+    ini_file = 'tests.ini'
 
     hg = hashes['goog']
     hm = hashes['moz']
-
-    def setUp(self):
-        self.maxDiff = None
 
     def test_parse_download(self):
         """
@@ -106,7 +110,11 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(p, d)
 
     def test_parse_download_errors(self):
-        pass
+        self.assertRaises(LimitExceededError, parse_downloads,
+                          dummy("mozpub-track-digest256;a:1-20000"))
+
+        self.assertRaises(LimitExceededError, parse_downloads,
+                          dummy("mozpub-track-digest256;a:1-1002"))
 
     def test_parse_gethash(self):
         h = "4:32\n"

--- a/shavar/tests/tests.ini
+++ b/shavar/tests/tests.ini
@@ -3,6 +3,7 @@ default_proto_ver = 2.0
 lists_served = mozpub-track-digest256
                moz-abp-shavar
 lists_root = tests
+max_downloads_chunks = 1000
 
 [mozpub-track-digest256]
 type = digest256


### PR DESCRIPTION
Turns out that no limits on the number of chunks a client can report in a request in combination with using time_t as a chunks numbers makes for some hilariously bad behaviour. @rfk r?