### PR TITLE
Better fix for non-delta publishing(issue #27)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'requirements.txt')) as f:
 
 
 setup(name='shavar',
-      version='0.1',
+      version='0.6',
       description='shavar',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[

--- a/shavar/tests/test_views.py
+++ b/shavar/tests/test_views.py
@@ -75,10 +75,10 @@ class NoDeltaViewTests(ShavarTestCase):
     def test_2_downloads_view(self):
         from shavar.views import downloads_view
 
-        req = "mozpub-track-digest256;a:1-2:s:6"
+        req = "mozpub-track-digest256;a:1-2,7,9-14,16:s:6"
         expected = "n:2700\n" \
                    "i:mozpub-track-digest256\n" \
-                   "ad:1-16\n" \
+                   "ad:1,2,7,9,10,11,12,13,14,16\n" \
                    "a:17:32:64\n" \
                    "\xd0\xe1\x96\xa0\xc2]5\xdd\n\x84Y<\xba\xe0\xf3\x833\xaaX" \
                    "R\x996DN\xa2dS\xea\xb2\x8d\xfc\x86\xfdm~\xb5\xf82\x1f" \

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -105,10 +105,10 @@ def format_downloads(request, resp_payload):
 
         # Chunk deletion commands come first
         if 'adddels' in ldata:
-            dels = ','.join(['%d' % num for num in ldata['adddels']])
+            dels = ','.join(['{0}'.format(num) for num in ldata['adddels']])
             body += 'ad:{0}\n'.format(dels)
         if 'subdels' in ldata:
-            dels = ','.join(['%d' % num for num in ldata['subdels']])
+            dels = ','.join(['{0}'.format(num) for num in ldata['subdels']])
             body += 'sd:{0}\n'.format(dels)
 
         # TODO  Should we prioritize subs over adds?


### PR DESCRIPTION
In this week's thrilling episode, our hero realizes he was an idiot several
times over but adroitly avoids disaster with some last minute hacking to
provide a saner fix for the ugly OOM causing feature that breaks clients!

This change actually makes use of the data parse from the client request to
provide an explicit list of chunks to delete.  Due to the internal data
structures that expand ranges after parsing, I decided to forego coalescing
those from their constiuent chunk numbers.  This just means that the client
will get a long-ish list of chunks to delete the first time they connect after
deployment.