### PR TITLE
Quick fix for broken unittest2 dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,7 @@ mozsvc==0.8
 # mozsvc has some wonky issues with testing dependencies
 #
 WSGIProxy
-unittest2
+# unittest v1.0.0 and v1.0.1 have a dependency on linecache2.  linecache2 is
+# currently experiencing syntax errors when you attempt to install it.
+unittest2==0.8.0
 webtest

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'requirements.txt')) as f:
 
 
 setup(name='shavar',
-      version='0.6',
+      version='0.6.1',
       description='shavar',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[


### PR DESCRIPTION
Downgrading unittest2 to a previous version because one of its dependencies is
horked.  Bumping the release as a consequence.