### PR TITLE
Fixes for gethash issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'requirements.txt')) as f:
 
 
 setup(name='shavar',
-      version='0.6.1',
+      version='0.6.2',
       description='shavar',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[

--- a/shavar/parse.py
+++ b/shavar/parse.py
@@ -89,7 +89,7 @@ def parse_gethash(request):
     # of 2**8 bytes and a minimum of 3("4:4", a single prefix).  256 is
     # probably waaaaaaaaaaay too large for a gethash request header.
     eoh = request.body.find('\n')
-    if eoh <= 3 or eoh >= 256:
+    if eoh < 3 or eoh >= 256:
         raise ParseError("Improbably small or large gethash header size: %d"
                          % eoh)
 
@@ -102,7 +102,7 @@ def parse_gethash(request):
     except ValueError:
         raise ParseError('Invalid prefix or payload size: "%s"' % header)
     if payload_len % prefix_len != 0:
-        raise ParseError("Body length invalid: \"%d\"" % payload_len)
+        raise ParseError("Payload length invalid: \"%d\"" % payload_len)
 
     prefix_total = payload_len / prefix_len
     prefixes_read = 0

--- a/shavar/tests/test_parse.py
+++ b/shavar/tests/test_parse.py
@@ -1,6 +1,7 @@
 import hashlib
 import StringIO
 
+from shavar.exceptions import ParseError
 from shavar.parse import parse_downloads, parse_gethash, parse_file_source
 from shavar.types import (
     Chunk,
@@ -132,9 +133,42 @@ class ParseTest(ShavarTestCase):
             s += i
         p = parse_gethash(dummy(s, path="/gethash"))
         self.assertEqual(p, set(d))
+        # Make sure no repeats of issue #32 pop up: test with a single hash
+        # prefix
+        s = "4:4\n\xdd\x01J\xf5"
+        p = parse_gethash(dummy(s, path="/gethash"))
 
     def test_parse_gethash_errors(self):
-        pass
+        # Too short
+        with self.assertRaises(ParseError) as ecm:
+            parse_gethash(dummy("4:\n"))
+        self.assertEqual(str(ecm.exception),
+                         "Improbably small or large gethash header size: 2")
+        # Too long
+        with self.assertRaises(ParseError) as ecm:
+            parse_gethash(dummy("4:" + "1" * 256 + "\n"))
+        self.assertEqual(str(ecm.exception),
+                         "Improbably small or large gethash header size: 258")
+        # Invalid sizes
+        with self.assertRaises(ParseError) as ecm:
+            parse_gethash(dummy("steve:4\n"))
+        self.assertEqual(str(ecm.exception),
+                         'Invalid prefix or payload size: "steve:4\n"')
+        with self.assertRaises(ParseError) as ecm:
+            parse_gethash(dummy("4:steve\n"))
+        self.assertEqual(str(ecm.exception),
+                         'Invalid prefix or payload size: "4:steve\n"')
+        # Improper payload length
+        with self.assertRaises(ParseError) as ecm:
+            parse_gethash(dummy("4:17\n"))
+        self.assertEqual(str(ecm.exception),
+                         'Payload length invalid: "17"')
+        # It seems some clients are hitting the gethash endpoint with a
+        # request intended for the downloads endpoint
+        with self.assertRaises(ParseError) as ecm:
+            parse_gethash(dummy("mozpub-track-digest256;a:1423242002"))
+        self.assertEqual(str(ecm.exception),
+                         "Improbably small or large gethash header size: -1")
 
     def test_parse_file_source(self):
         d = ''.join([self.hm, self.hg])

--- a/shavar/tests/test_parse.py
+++ b/shavar/tests/test_parse.py
@@ -137,6 +137,7 @@ class ParseTest(ShavarTestCase):
         # prefix
         s = "4:4\n\xdd\x01J\xf5"
         p = parse_gethash(dummy(s, path="/gethash"))
+        self.assertEqual(p, set(["\xdd\x01J\xf5"]))
 
     def test_parse_gethash_errors(self):
         # Too short

--- a/shavar/tests/test_views.py
+++ b/shavar/tests/test_views.py
@@ -66,6 +66,11 @@ class DeltaViewTests(ShavarTestCase):
         request = dummy(body, path='/gethash')
         response = gethash_view(request)
         self.assertEqual(response.body, expected)
+        # Make sure we return a 204 No Content for a prefix that doesn't map
+        # to a hash we're serving
+        request = dummy("4:4\n\x00\x00\x00\x00", path='/gethash')
+        response = gethash_view(request)
+        self.assertEqual(response.code, 204)
 
 
 class NoDeltaViewTests(ShavarTestCase):


### PR DESCRIPTION
- Permit single prefix requests
- Return a 204(as spec'd) when no matching hash is found for a prefix
- More thorough tests for gethash error conditions

I am very surprised that these haven't been in production for months.  The
work was done then I didn't push.  I suspect it was due to the confusion about
which release was actually running in production at the time.

r? @rfk