### PR TITLE
Properly send adddels with not_publishing_deltas

### DIFF
--- a/shavar/tests/test_views.py
+++ b/shavar/tests/test_views.py
@@ -93,3 +93,19 @@ class NoDeltaViewTests(ShavarTestCase):
         request = dummy(req, path='/downloads')
         response = downloads_view(request)
         self.assertEqual(response.body, expected)
+
+        # New downloads request means there should be no adddel or subdel
+        # entries in the response even if not_publishing_deltas is enabled
+        # for the list.
+        req = "mozpub-track-digest256;"
+        expected = "n:2700\n" \
+                   "i:mozpub-track-digest256\n" \
+                   "a:17:32:64\n" \
+                   "\xd0\xe1\x96\xa0\xc2]5\xdd\n\x84Y<\xba\xe0\xf3\x833\xaaX" \
+                   "R\x996DN\xa2dS\xea\xb2\x8d\xfc\x86\xfdm~\xb5\xf82\x1f" \
+                   "\x8a\xden)\\;RW\xcaK\xb0\x90V1Z\x0bz\xe3?\xf6\x00\x81g" \
+                   "\xcd\x97"
+
+        request = dummy(req, path='/downloads')
+        response = downloads_view(request)
+        self.assertEqual(response.body, expected)

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -106,10 +106,10 @@ def format_downloads(request, resp_payload):
         body += "i:%s\n" % lname
 
         # Chunk deletion commands come first
-        if 'adddels' in ldata:
+        if 'adddels' in ldata and ldata['adddels']:
             dels = ','.join(['{0}'.format(num) for num in ldata['adddels']])
             body += 'ad:{0}\n'.format(dels)
-        if 'subdels' in ldata:
+        if 'subdels' in ldata and ldata['subdels']:
             dels = ','.join(['{0}'.format(num) for num in ldata['subdels']])
             body += 'sd:{0}\n'.format(dels)
 


### PR DESCRIPTION
Fixes issue #38.  When not_publishing_deltas is enabled for a list, only
include an "ad:" line when there are actually chunks to be dropped from the
client.