### PR TITLE
Fix missing data freshness check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'requirements.txt')) as f:
 
 
 setup(name='shavar',
-      version='0.6.3',
+      version='0.6.5.2',
       description='shavar',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -18,11 +18,13 @@ def includeme(config):
     for lname in lists_to_serve:
         # Make sure we have a refresh interval set for the data source for the
         # lists
+        setting_name = 'refresh_check_interval'
         settings = config.registry.settings.getsection(lname)
-        default = config.registry.settings.get('refresh_check_interval',
-                                               12 * 60 * 60)
-        if 'refresh_check_interval' not in settings:
-            settings['refresh_check_interval'] = default
+        default = config.registry.settings.get('shavar.%s' %
+                                               setting_name,
+                                               10 * 60)
+        if setting_name not in settings:
+            settings[setting_name] = default
 
         # defaults = config.get_map('shavar')
         # settings = {'type': 'shavar',
@@ -98,7 +100,7 @@ class SafeBrowsingList(object):
         self.settings = settings
 
         scheme = self.url.scheme.lower()
-        interval = settings.get('refresh_check_interval', 12 * 60 * 60)
+        interval = settings.get('refresh_check_interval', 10 * 60)
         if (scheme == 'file' or not (self.url.scheme and self.url.netloc)):
             self._source = FileSource(self.source_url,
                                       refresh_interval=interval)

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -60,3 +60,15 @@ class S3SourceListsTest(ShavarTestCase):
         sblist = get_list(dumdum, 'mozpub-track-digest256')
         self.assertIsInstance(sblist, Digest256)
         self.assertEqual(sblist.delta([1, 2], [3]), ([4, 5], [6]))
+
+
+class DataRefreshTest(ShavarTestCase):
+
+    def test_5_data_refresh(self):
+        dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
+        d = dumdum.registry.settings.get('shavar.refresh_check_interval')
+        self.assertEqual(d, 29)
+        l = dumdum.registry['shavar.serving']['moz-abp-shavar']
+        self.assertEqual(l._source.interval, 29)
+        l = dumdum.registry['shavar.serving']['mozpub-track-digest256']
+        self.assertEqual(l._source.interval, 23)

--- a/shavar/tests/tests.ini
+++ b/shavar/tests/tests.ini
@@ -4,10 +4,12 @@ lists_served = mozpub-track-digest256
                moz-abp-shavar
 lists_root = tests
 max_downloads_chunks = 1000
+refresh_check_interval = 29
 
 [mozpub-track-digest256]
 type = digest256
 source = shavar/tests/chunk_source
+refresh_check_interval = 23
 
 [moz-abp-shavar]
 type = shavar


### PR DESCRIPTION
This managed to get left out of PR #48 for reasons that are quite beyond me.
Properly check for the refresh_check_interval at the list level and at the
global level.

Change the hard coded, fallback default to 10 minutes.

Add a test to actually make sure the config setting works

r? @telliott 