### PR TITLE
Additions to make it possible to silence HTTP 200 logging for prod

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = W503,E241

--- a/shavar.testing.ini
+++ b/shavar.testing.ini
@@ -69,7 +69,9 @@ level = NOTSET
 formatter = generic
 
 [formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
+#format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
+# The following will replicate production logging styles:
+class = mozsvc.util.JsonLogFormatter
 
 [heka]
 logger = shavar
@@ -99,6 +101,10 @@ default_proto_ver = 2.0
 # are not provided in the list specific stanzas.  Not necessary if you
 # provide absolute paths.
 lists_root = tests
+# In production, the shavar service has so much traffic that logging 200s from
+# the app directly causes disk utilization issues.  A lame hack to make it
+# possible to quiet the service.  Only affects HTTP 200s.
+stfu_200_logging = False
 
 [mozpub-track-digest256]
 # The type of list data that will be shipped.  Presumably this has some

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -55,7 +55,7 @@ def shut_up_common_log_200s():
 
         def filter(self, record):
             if ('code' in record.__dict__ and
-                record.__dict__['code'] == 200):
+                    record.__dict__['code'] == 200):
                 return 0
             return 1
 

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -34,6 +34,34 @@ def includeme(config):
     config.add_route('newkey', '/newkey')
     config.add_view(newkey_view, route_name='newkey', request_method='GET')
 
+    if config.registry.settings.get('shavar.stfu_200_logging', False):
+        shut_up_common_log_200s()
+
+
+def shut_up_common_log_200s():
+    class StfuWsgi200LogFilter(object):
+        """Mute the wsgi access logger"""
+
+        def filter(self, record):
+            if '" 200 ' in record.msg:
+                return 0
+            return 1
+
+    frogger = logging.getLogger('wsgi')
+    frogger.addFilter(StfuWsgi200LogFilter())
+
+    class StfuMetrics200sLogFilter(object):
+        """Drop HTTP 200s on the floor to minimize disk issues in prod."""
+
+        def filter(self, record):
+            if ('code' in record.__dict__ and
+                record.__dict__['code'] == 200):
+                return 0
+            return 1
+
+    frogger = logging.getLogger('mozsvc.metrics')
+    frogger.addFilter(StfuMetrics200sLogFilter())
+
 
 def _setting(request, section, key, default=None):
     return request.registry.settings.get("%s.%s" % (section, key), default)


### PR DESCRIPTION
Add logging.LogFilter to both the mozsvc.metrics and wsgi loggers so they
will STFU with the 200s already.

r? @fmarier 