### PR TITLE
Remove oversize gethash request check

### DIFF
--- a/shavar/parse.py
+++ b/shavar/parse.py
@@ -118,9 +118,6 @@ def parse_gethash(request):
         prefixes_read += 1
         parsed.append(prefix)
 
-    if body_file.peek(prefix_len):
-        raise ParseError("Oversized payload!")
-
     if prefixes_read != prefix_total:
         raise ParseError("Hash read mismatch: client claimed %d, read %d" %
                          (prefix_total, prefixes_read))

--- a/shavar/tests/test_parse.py
+++ b/shavar/tests/test_parse.py
@@ -203,10 +203,6 @@ class ParseTest(ShavarTestCase):
             parse_gethash(dummy("4:8\n\xdd\x01J\xf5\xedk8"))
         self.assertEqual(str(ecm.exception),
                          "Hash read mismatch: client claimed 2, read 1")
-        # Extraneous trailing data
-        with self.assertRaises(ParseError) as ecm:
-            parse_gethash(dummy("4:8\n\xdd\x01J\xf5\xedk8\xd9\x13\x0e?F"))
-        self.assertEqual(str(ecm.exception), "Oversized payload!")
 
     def test_parse_file_source(self):
         d = ''.join([self.hm, self.hg])


### PR DESCRIPTION
io.IOBytes doesn't have a peek() method.  Pyramid's DummyRequest body_file
apparently isn't instantiated as an IOBytes object.  Another victim to
significant departures in Pyramid's testing infrastructure from normal
production behaviour, sadly.

r? @fmarier 