### PR TITLE
Start up script changes and optional new relic support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 .cache
+newrelic.ini

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ docs/_build/
 
 # Ignore the generated version.json file
 version.json
+
+# Ignore newrelic.ini if present
+newrelic.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:2.7
 ENV NEWRELIC_LIC_KEY ${NEWRELIC_LIC_KEY:-"1234"}
 ENV ENABLE_NEWRELIC $ENABLE_NEWRELIC
-RUN groupadd -g 10001 app && \
-      useradd -d /app -g 10001 -G app -M -s /bin/sh -u 10001 app
+RUN useradd -d /app -M -s /bin/sh -u 10001 -U app
 WORKDIR /app
 ENTRYPOINT ["/app/startup.sh"]
 CMD ["START"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM python:2.7
-RUN groupadd -g 10001 app && useradd -d /app -g 10001 -G app -M -s /bin/sh -u 10001 app
+ENV NEWRELIC_LIC_KEY ${NEWRELIC_LIC_KEY:-"1234"}
+ENV ENABLE_NEWRELIC $ENABLE_NEWRELIC
+RUN groupadd -g 10001 app && \
+      useradd -d /app -g 10001 -G app -M -s /bin/sh -u 10001 app
 WORKDIR /app
 ENTRYPOINT ["/app/startup.sh"]
 CMD ["START"]
 EXPOSE 8080
 COPY . /app
-RUN pip install -r requirements.txt --no-cache-dir --disable-pip-version-check \
-    && python setup.py install && chown -R app:app /app
+RUN pip install -r requirements.txt --no-cache-dir --disable-pip-version-check && \
+      pip install newrelic
+RUN python setup.py install && chown -R app:app /app

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ dependencies:
       I="image-$(date +%j).tar"; mkdir -p ~/docker; rm ~/docker/*; docker save app:build > ~/docker/$I; ls -l ~/docker
 test:
   override:
-    - docker run -d --net=host app:build; sleep 10
+    - docker run -d --net=host app:build START; sleep 10
     - curl -d " " --retry 10 --retry-delay 5 -v 'http://localhost:8080/list?client=foo&appver=1&pver=2.2'
 deployment:
   hub_latest:
@@ -41,3 +41,9 @@ deployment:
       - "docker tag app:build ${DOCKERHUB_REPO}:${CIRCLE_TAG}"
       - "docker images"
       - "docker push ${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+  hub_testing:
+    branch: /testing_.*/
+    commands:
+        - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+        - "docker tag app:build ${DOCKERHUB_REPO}:${CIRCLE_BRANCH}"
+        - "docker push ${DOCKERHUB_REPO}:${CIRCLE_BRANCH}"

--- a/startup.sh
+++ b/startup.sh
@@ -1,9 +1,58 @@
 #!/bin/bash
-test -n "$1" && ARG=$(echo $1 | tr [a-z] [A-Z])
-if [[ "$ARG" == "START" ]]; then
-  test -x /usr/local/bin/uwsgi && \
-      /usr/local/bin/uwsgi --ini-paste shavar.ini --paste-logger --uid 10001 --gid 10001
+
+
+function start {
+  if [ "$RUN_NEWRELIC" == "TRUE" ]; then
+    NEW_RELIC_CONFIG_FILE="./newrelic.ini" newrelic-admin run-program /usr/local/bin/uwsgi --ini-paste shavar.ini --paste-logger --uid 10001 --gid 10001
+  else
+     exec /usr/local/bin/uwsgi --ini-paste shavar.ini --paste-logger --uid 10001 --gid 10001
+  fi
+}
+
+
+function deploy {
+  if [ "$RUN_NEWRELIC" == "TRUE" ]; then
+    HASH=$(cat version.json | cut -d":" -f2|cut -d"," -f1 | tr -d "\"")
+    REPO=$(cat version.json | cut -d"\"" -f12)
+    newrelic-admin record-deploy ./newrelic.ini ${HASH:7} ${REPO} svcops
+  else
+    /bin/false
+  fi
+}
+
+
+if [ -n "$1" ]; then
+  COMMAND=$(echo $1 | tr [a-z] [A-Z])
 else
-  echo "Invalid option specified: ARG=$ARG"
-  exit
-fi  
+  exit 1
+fi
+
+if env | grep -q "ENABLE_NEWRELIC"; then
+  declare -x "RUN_NEWRELIC=TRUE"
+  if [ -e newrelic.ini ]; then
+    /bin/true
+  else
+    newrelic-admin generate-config ${NEWRELIC_LIC_KEY} newrelic.ini
+    sed -i -e 's@app_name = Python Application@app_name = Shavar@' newrelic.ini
+  fi
+fi
+
+if [ -x /usr/local/bin/uwsgi ]; then
+  case "$COMMAND" in
+    START)
+      start
+      exit 0
+      ;;
+    DEPLOY)
+      deploy
+      exit 0
+      ;;
+    *)
+      echo "Invalid option specified: ARG=$COMMAND"
+      exit 1
+      ;;
+  esac
+else
+  echo "uwsgi is not installed"
+  exit 1
+fi

--- a/startup.sh
+++ b/startup.sh
@@ -37,22 +37,22 @@ if env | grep -q "ENABLE_NEWRELIC"; then
   fi
 fi
 
-if [ -x /usr/local/bin/uwsgi ]; then
-  case "$COMMAND" in
-    START)
+case "$COMMAND" in
+  START)
+    if [ -x /usr/local/bin/uwsgi ]; then
       start
       exit 0
-      ;;
-    DEPLOY)
-      deploy
-      exit 0
-      ;;
-    *)
-      echo "Invalid option specified: ARG=$COMMAND"
+    else
+      echo "uwsgi is not installed"
       exit 1
-      ;;
-  esac
-else
-  echo "uwsgi is not installed"
-  exit 1
-fi
+    fi
+    ;;
+  DEPLOY)
+    deploy
+    exit 0
+    ;;
+  *)
+    echo "Invalid option specified: ARG=$COMMAND"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
add an exec to the start up script
pass START arg to circle test
missing space; added
add a push for testing_.* branches
add code required to install the newrelic agent in the container if desired
add logic to start via the newrelic wrapper if -e ENABLE_NEWRELIC is set on the docker run command line
circleci's docker doesn't support the ARG spec. Lame.
ignore newrelic.ini if it exists
require newrelic
unstage change to requirements.txt
Dockerfile changes
- set a sane default for NEWRELIC_LIC_KEY
- Don't generate newrelic.ini on container build, generate at runtime in
response to ENV vars set on command line instead
startup.sh changes
if ENABLE_NEWRELIC is set and the config file doesn't exist. Generate
one and set the appropriate app name. The newrelic-admin script is brain
dead and doesn't accept any options for setting this.
Check to make sure RUN_NEWRELIC is actually set to TRUE. Quote ENV
setting too
s/;/:/
add a DEPLOY option to startup script if newrelic is enabled