### PR TITLE
Add flake8 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ WSGIProxy
 # currently experiencing syntax errors when you attempt to install it.
 unittest2==0.8.0
 webtest
+flake8


### PR DESCRIPTION
Your install instructions specify to make a virtualenv and run make test, which does not work without flake8.