### PR TITLE
Get versioned lists from S3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pastescript==2.0.2
 pyramid==1.9
 pyramid_chameleon==0.3
 pyramid_debugtoolbar==2.1
+requests==2.22.0
 raven==5.12.0
 statsd==3.0
 waitress==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 boto==2.31.1
 konfig==0.9
 Paste==1.7.5.1
+packaging==19.2
 pastescript==2.0.2
 pyramid==1.9
 pyramid_chameleon==0.3

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -158,18 +158,16 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
     ver = version.parse(app_version)
     # need to be wary of ESR, it's considered legacy version in packaging
     if not isinstance(ver, version.Version) or not supported_versions:
-        return list_name, None
+        return list_name
 
     default_ver = version.parse(OLDEST_SUPPORTED_VERSION)
     is_default_version = (
         ver.release and ver.release[0] <= default_ver.release[0])
     if is_default_version:
-        return (
-            get_versioned_list_name(default_ver.public, list_name),
-            default_ver.public)
+        return get_versioned_list_name(default_ver.public, list_name)
 
     if ver.public in supported_versions:
-        return get_versioned_list_name(ver.public, list_name), ver.public
+        return get_versioned_list_name(ver.public, list_name)
 
     # truncate version to be less specific to lazy match
     truncate_ind = -1
@@ -177,11 +175,11 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
         if app_version[:truncate_ind] in supported_versions:
             versioned_list_name = get_versioned_list_name(
                 app_version[:truncate_ind], list_name)
-            return versioned_list_name, app_version[:truncate_ind]
+            return versioned_list_name
         truncate_ind -= 1
 
     # if none of the supported versions match, match with master
-    return list_name, None
+    return list_name
 
 
 def get_list(request, list_name, app_ver='none'):
@@ -189,10 +187,10 @@ def get_list(request, list_name, app_ver='none'):
         errmsg = 'Not serving requested list "%s"' % (list_name,)
         raise MissingListDataError(errmsg)
     all_supported_versions = request.registry['shavar.versioned_lists']
-    list_name, list_ver = match_with_versioned_list(
+    list_name = match_with_versioned_list(
         app_ver, all_supported_versions.get(list_name), list_name)
     registry_val = request.registry['shavar.serving'][list_name]
-    return registry_val, list_ver
+    return registry_val
 
 
 def lookup_prefixes(request, prefixes):

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -179,6 +179,7 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
 
 
 def get_list(request, list_name, app_ver):
+def get_list(request, list_name, app_ver='none'):
     if list_name not in request.registry['shavar.serving']:
         errmsg = 'Not serving requested list "%s"' % (list_name,)
         raise MissingListDataError(errmsg)

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -179,7 +179,6 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
 
 
 def get_list(request, list_name, app_ver):
-def get_list(request, list_name, app_ver='none'):
     if list_name not in request.registry['shavar.serving']:
         errmsg = 'Not serving requested list "%s"' % (list_name,)
         raise MissingListDataError(errmsg)

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -181,6 +181,9 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
             return versioned_list_name, app_version[:truncate_ind]
         truncate_ind -= 1
 
+    # if none of the supported versions match, match with master
+    return list_name, None
+
 
 def get_list(request, list_name, app_ver='none'):
     if list_name not in request.registry['shavar.serving']:

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -15,6 +15,7 @@ from shavar.sources import (
 
 
 logger = logging.getLogger('shavar')
+OLDEST_SUPPORTED_VERSION = '69.0'
 GITHUB_API_URL = 'https://api.github.com'
 SHAVAR_PROD_LISTS_BRANCHES_PATH = (
     '/repos/mozilla-services/shavar-prod-lists/branches'
@@ -160,7 +161,7 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
     if not isinstance(ver, version.Version) or not supported_versions:
         return list_name, None
 
-    default_ver = version.parse('69.0')
+    default_ver = version.parse(OLDEST_SUPPORTED_VERSION)
     is_default_version = (
         ver.release and ver.release[0] <= default_ver.release[0])
     if is_default_version:

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -36,7 +36,7 @@ def get_versioned_list_name(version, list_name):
     return '{0}-{1}'.format(version, list_name)
 
 
-def add_versionted_lists_to_registry(settings, config, type_, list_name):
+def add_versioned_lists_to_registry(settings, config, type_, list_name):
     resp = requests.get(GITHUB_API_URL + SHAVAR_PROD_LISTS_BRANCHES_PATH)
     shavar_prod_lists_branches = resp.json()
     for branch in shavar_prod_lists_branches:
@@ -147,7 +147,7 @@ def includeme(config):
             and list_config.get(list_name, 'versioned')
         )
         if versioned:
-            add_versionted_lists_to_registry(
+            add_versioned_lists_to_registry(
                 settings, config, type_, list_name)
     config.registry.settings['shavar.list_names_served'] = [
         list['name'] for list in list_configs

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -15,6 +15,17 @@ from shavar.sources import (
 logger = logging.getLogger('shavar')
 
 
+def create_list(type_, list_name, settings):
+    if type_ == 'digest256':
+        list_ = Digest256(list_name, settings['source'], settings)
+    elif type_ == 'shavar':
+        list_ = Shavar(list_name, settings['source'], settings)
+    else:
+        raise ValueError('Unknown list type for "%s": "%s"' % (list_name,
+                                                               type_))
+    return list_
+
+
 def includeme(config):
     lists_to_serve = config.registry.settings.get('shavar.lists_served', None)
     if not lists_to_serve:
@@ -90,14 +101,7 @@ def includeme(config):
         #                                                ''), lname)}
 
         type_ = list_config.get(list_name, 'type')
-        if type_ == 'digest256':
-            list_ = Digest256(list_name, settings['source'], settings)
-        elif type_ == 'shavar':
-            list_ = Shavar(list_name, settings['source'], settings)
-        else:
-            raise ValueError('Unknown list type for "%s": "%s"' % (list_name,
-                                                                   type_))
-
+        list_ = create_list(type_, list_name, settings)
         config.registry['shavar.serving'][list_name] = list_
 
     config.registry.settings['shavar.list_names_served'] = [

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -54,6 +54,8 @@ def add_versionted_lists_to_registry(settings, config, type_, list_name):
             versioned_list_name = get_versioned_list_name(
                 branch_name, list_name)
             config.registry['shavar.serving'][versioned_list_name] = list_
+            config.registry['shavar.versioned_lists'][list_name].append(
+                branch_name)
             # revert settings
             original_source = settings['source'].replace(
                 'tracking/{}/'.format(branch_name), 'tracking/')
@@ -73,6 +75,7 @@ def includeme(config):
     list_configs = []
 
     config.registry['shavar.serving'] = {}
+    config.registry['shavar.versioned_lists'] = {}
 
     if lists_to_serve_scheme == 'dir':
         import os
@@ -137,6 +140,7 @@ def includeme(config):
         type_ = list_config.get(list_name, 'type')
         list_ = create_list(type_, list_name, settings)
         config.registry['shavar.serving'][list_name] = list_
+        config.registry['shavar.versioned_lists'][list_name] = []
 
         versioned = (
             list_config.has_option(list_name, 'versioned') and list_config.get(list_name, 'versioned')

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -15,6 +15,10 @@ from shavar.sources import (
 
 
 logger = logging.getLogger('shavar')
+GITHUB_API_URL = 'https://api.github.com'
+SHAVAR_PROD_LISTS_BRANCHES_PATH = (
+    '/repos/mozilla-services/shavar-prod-lists/branches'
+)
 
 
 def create_list(type_, list_name, settings):

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -175,8 +175,9 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
     truncate_ind = -1
     while len(app_version) != abs(truncate_ind):
         if app_version[:truncate_ind] in supported_versions:
-            return get_versioned_list_name(
-                app_version[:truncate_ind], list_name), app_version[:truncate_ind]
+            versioned_list_name = get_versioned_list_name(
+                app_version[:truncate_ind], list_name)
+            return versioned_list_name, app_version[:truncate_ind]
         truncate_ind -= 1
 
 

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -54,8 +54,8 @@ def includeme(config):
             conn = boto.connect_s3()
             bucket = conn.get_bucket(lists_to_serve_url.netloc)
         except S3ResponseError, e:
-                raise NoDataError("Could not find bucket \"%s\": %s" %
-                                  (lists_to_serve_url.netloc, e))
+            raise NoDataError("Could not find bucket \"%s\": %s" %
+                              (lists_to_serve_url.netloc, e))
         for list_key in bucket.get_all_keys():
             list_key_name = list_key.key
             list_name = list_key_name.rstrip('.ini')

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -153,10 +153,13 @@ def includeme(config):
     ]
 
 
-def get_list(request, list_name):
+def get_list(request, list_name, app_ver):
     if list_name not in request.registry['shavar.serving']:
         errmsg = 'Not serving requested list "%s"' % (list_name,)
         raise MissingListDataError(errmsg)
+    all_supported_versions = request.registry['shavar.versioned_lists']
+    list_name = match_with_versioned_list(
+        app_ver, all_supported_versions.get(list_name), list_name)
     return request.registry['shavar.serving'][list_name]
 
 

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -37,16 +37,13 @@ def get_versioned_list_name(version, list_name):
     return '{0}-{1}'.format(version, list_name)
 
 
-def add_versioned_lists_to_registry(settings, config, type_, list_name):
-    resp = requests.get(GITHUB_API_URL + SHAVAR_PROD_LISTS_BRANCHES_PATH)
-    shavar_prod_lists_branches = resp.json()
+def add_versioned_lists_to_registry(
+        settings, config, type_, list_name, shavar_prod_lists_branches):
     for branch in shavar_prod_lists_branches:
         branch_name = branch.get('name')
         ver = version.parse(branch_name)
         if isinstance(ver, version.Version):
-            # Add version to list config to retrieve later
-            # check if the version exists in S3?
-            # change config to reflect verion branches
+            # change config to reflect version branches
             versioned_source = settings['source'].replace(
                 'tracking/', 'tracking/{}/'.format(branch_name))
             settings['source'] = versioned_source
@@ -119,6 +116,8 @@ def includeme(config):
     else:
         raise ValueError('lists_served must be dir:// or s3+dir:// value')
 
+    resp = requests.get(GITHUB_API_URL + SHAVAR_PROD_LISTS_BRANCHES_PATH)
+    shavar_prod_lists_branches = resp.json()
     for list_config in list_configs:
         list_name = list_config['name']
         list_config = list_config['config']
@@ -149,7 +148,7 @@ def includeme(config):
         )
         if versioned:
             add_versioned_lists_to_registry(
-                settings, config, type_, list_name)
+                settings, config, type_, list_name, shavar_prod_lists_branches)
     config.registry.settings['shavar.list_names_served'] = [
         list['name'] for list in list_configs
     ]

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -32,6 +32,10 @@ def create_list(type_, list_name, settings):
     return list_
 
 
+def get_versioned_list_name(version, list_name):
+    return '{0}-{1}'.format(version, list_name)
+
+
 def includeme(config):
     lists_to_serve = config.registry.settings.get('shavar.lists_served', None)
     if not lists_to_serve:
@@ -128,7 +132,8 @@ def includeme(config):
                     settings['source'] = versioned_source
                     # get new list for the version
                     list_ = create_list(type_, list_name, settings)
-                    versioned_list_name = '{0}-{1}'.format(branch_name, list_name)
+                    versioned_list_name = get_versioned_list_name(
+                        branch_name, list_name)
                     config.registry['shavar.serving'][versioned_list_name] = list_
                     # revert settings
                     original_source = settings['source'].replace(

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -143,7 +143,8 @@ def includeme(config):
         config.registry['shavar.versioned_lists'][list_name] = []
 
         versioned = (
-            list_config.has_option(list_name, 'versioned') and list_config.get(list_name, 'versioned')
+            list_config.has_option(list_name, 'versioned')
+            and list_config.get(list_name, 'versioned')
         )
         if versioned:
             add_versionted_lists_to_registry(

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -153,6 +153,30 @@ def includeme(config):
     ]
 
 
+def match_with_versioned_list(app_version, supported_versions, list_name):
+    ver = version.parse(app_version)
+    # need to be wary of ESR, it's considered legacy version in packaging
+    if not isinstance(ver, version.Version) or not supported_versions:
+        return list_name
+
+    default_ver = version.parse('69.0')
+    is_default_version = (
+        ver.release and ver.release[0] <= default_ver.release[0])
+    if is_default_version:
+        return get_versioned_list_name(default_ver.public, list_name)
+
+    if ver.public in supported_versions:
+        return get_versioned_list_name(ver.public, list_name)
+
+    # truncate version to be less specific to lazy match
+    truncate_ind = -1
+    while len(app_version) != abs(truncate_ind):
+        if app_version[:truncate_ind] in supported_versions:
+            return get_versioned_list_name(
+                app_version[:truncate_ind], list_name)
+        truncate_ind -= 1
+
+
 def get_list(request, list_name, app_ver):
     if list_name not in request.registry['shavar.serving']:
         errmsg = 'Not serving requested list "%s"' % (list_name,)

--- a/shavar/parse.py
+++ b/shavar/parse.py
@@ -108,8 +108,8 @@ def parse_gethash(request):
         prefix_len, payload_len = [int(x) for x in header.split(':', 1)]
     except ValueError:
         raise ParseError('Invalid prefix or payload size: "%s"' % header)
-    if ((payload_len % prefix_len != 0) or
-            (payload_len < prefix_len)):
+    if ((payload_len % prefix_len != 0)
+            or (payload_len < prefix_len)):
         raise ParseError("Payload length invalid: \"%d\"" % payload_len)
 
     prefix_total = payload_len / prefix_len
@@ -247,7 +247,7 @@ def parse_dir_source(handle, exists_cb=os.path.exists, open_cb=open):
         raise ParseError("Could not parse index file: %s" % e)
 
     if 'name' not in index:
-            raise ParseError("Incorrectly formatted index: missing list name")
+        raise ParseError("Incorrectly formatted index: missing list name")
 
     if 'chunks' not in index:
         raise ParseError("Incorrectly formatted index: missing chunks")

--- a/shavar/sources.py
+++ b/shavar/sources.py
@@ -32,7 +32,7 @@ class Source(object):
         self.no_data = True
 
     def load(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     def _populate_chunks(self, fp, parser_func, *args, **kwargs):
         try:
@@ -109,8 +109,8 @@ class DirectorySource(FileSource):
     index_name = 'index.json'
 
     def __init__(self, source_url, refresh_interval):
-        if (source_url[-1] == '/' or
-                source_url[-len(self.index_name):] != self.index_name):
+        if (source_url[-1] == '/'
+                or source_url[-len(self.index_name):] != self.index_name):
             source_url = posixpath.join(source_url, self.index_name)
 
         # Relative path to a directory, tweak slightly so urlparse will parse
@@ -180,8 +180,8 @@ class S3DirectorySource(S3FileSource):
     index_name = 'index.json'
 
     def __init__(self, source_url, refresh_interval):
-        if (source_url[-1] == '/' or
-                source_url[-len(self.index_name):] != self.index_name):
+        if (source_url[-1] == '/'
+                or source_url[-len(self.index_name):] != self.index_name):
             source_url = posixpath.join(source_url, self.index_name)
         super(S3DirectorySource, self).__init__(source_url,
                                                 refresh_interval)

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -5,6 +5,7 @@ import boto
 from boto.s3.key import Key
 from moto import mock_s3
 
+from shavar.exceptions import MissingListDataError
 from shavar.lists import (
     get_list,
     lookup_prefixes,
@@ -35,7 +36,9 @@ class ListsTest(ShavarTestCase):
     def test_3_get_list_list_not_served(self):
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
         # sblist, list_ver = get_list(dumdum, 'this-list-dne')
-        self.assertRaises(MissingListDataError, get_list, (dumdum, 'this-list-dne'))
+        self.assertRaises(
+            MissingListDataError, get_list, dumdum, 'this-list-dne'
+        )
 
     def test_4_match_with_versioned_list_version_lower_than_supported(self):
         list_name, list_ver = match_with_versioned_list(

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -20,7 +20,7 @@ class ListsTest(ShavarTestCase):
 
     def test_0_get_list(self):
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
-        sblist, _ = get_list(dumdum, 'mozpub-track-digest256')
+        sblist = get_list(dumdum, 'mozpub-track-digest256')
         self.assertIsInstance(sblist, Digest256)
 
     def test_1_lookup_prefixes(self):
@@ -28,49 +28,38 @@ class ListsTest(ShavarTestCase):
         prefixes = lookup_prefixes(dumdum, [self.hg[:4]])
         self.assertEqual(prefixes, {'moz-abp-shavar': {17: [hashes['goog']]}})
 
-    def test_2_get_list_version_not_specified(self):
+    def test_2_get_list_list_not_served(self):
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
-        sblist, list_ver = get_list(dumdum, 'mozpub-track-digest256')
-        self.assertIsNone(list_ver)
-
-    def test_3_get_list_list_not_served(self):
-        dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
-        # sblist, list_ver = get_list(dumdum, 'this-list-dne')
+        sblist = get_list(dumdum, 'this-list-dne')
         self.assertRaises(
             MissingListDataError, get_list, dumdum, 'this-list-dne'
         )
 
+    def test_3_match_with_versioned_list_version_not_specified(self):
+        dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
+        list_name = match_with_versioned_list(
+            'none', ['70.0', '71.0'], 'mozpub-track-digest256')
+        self.assertEquals(list_name, 'mozpub-track-digest256')
+
     def test_4_match_with_versioned_list_version_lower_than_supported(self):
-        list_name, list_ver = match_with_versioned_list(
+        list_name = match_with_versioned_list(
             '68.0', ['70.0', '71.0'], 'mozpub-track-digest256')
-        self.assertEquals(
-            (list_name, list_ver),
-            ('69.0-mozpub-track-digest256', '69.0')
-        )
+        self.assertEquals(list_name, '69.0-mozpub-track-digest256')
 
     def test_5_match_with_versioned_list_version_exact_match(self):
-        list_name, list_ver = match_with_versioned_list(
+        list_name = match_with_versioned_list(
             '70.0', ['70.0', '71.0'], 'mozpub-track-digest256')
-        self.assertEquals(
-            (list_name, list_ver),
-            ('70.0-mozpub-track-digest256', '70.0')
-        )
+        self.assertEquals(list_name, '70.0-mozpub-track-digest256')
 
     def test_6_match_with_versioned_list_version_fuzzy_match(self):
-        list_name, list_ver = match_with_versioned_list(
+        list_name = match_with_versioned_list(
             '71.0a1', ['70.0', '71.0'], 'mozpub-track-digest256')
-        self.assertEquals(
-            (list_name, list_ver),
-            ('71.0-mozpub-track-digest256', '71.0')
-        )
+        self.assertEquals(list_name, '71.0-mozpub-track-digest256')
 
     def test_7_match_with_versioned_list_version_fuzzy_match(self):
-        list_name, list_ver = match_with_versioned_list(
+        list_name = match_with_versioned_list(
             '72.0a1', ['70.0', '71.0'], 'mozpub-track-digest256')
-        self.assertEquals(
-            (list_name, list_ver),
-            ('mozpub-track-digest256', None)
-        )
+        self.assertEquals(list_name, 'mozpub-track-digest256')
 
     def test_8_get_versioned_list_name(self):
         list_name = get_versioned_list_name('70.0', 'mozpub-track-digest256')
@@ -83,7 +72,7 @@ class DeltaListsTest(ShavarTestCase):
 
     def test_2_delta(self):
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
-        sblist, _ = get_list(dumdum, 'mozpub-track-digest256')
+        sblist = get_list(dumdum, 'mozpub-track-digest256')
         # By way of explanation:
         #
         # In the data file.
@@ -154,7 +143,7 @@ class S3SourceListsTest(ShavarTestCase):
         # Basically the same tests in test_0_get_list and test_2_delta above
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
         for list_ in ('mozpub-track-digest256', 'testpub-bananas-digest256'):
-            sblist, _ = get_list(dumdum, list_)
+            sblist = get_list(dumdum, list_)
             self.assertIsInstance(sblist, Digest256)
             self.assertEqual(sblist.delta([1, 2], [3]), ([4, 5], [6]))
 

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -13,7 +13,7 @@ class ListsTest(ShavarTestCase):
 
     def test_0_get_list(self):
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
-        sblist = get_list(dumdum, 'mozpub-track-digest256')
+        sblist, _ = get_list(dumdum, 'mozpub-track-digest256')
         self.assertIsInstance(sblist, Digest256)
 
     def test_1_lookup_prefixes(self):
@@ -28,7 +28,7 @@ class DeltaListsTest(ShavarTestCase):
 
     def test_2_delta(self):
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
-        sblist = get_list(dumdum, 'mozpub-track-digest256')
+        sblist, _ = get_list(dumdum, 'mozpub-track-digest256')
         # By way of explanation:
         #
         # In the data file.
@@ -99,7 +99,7 @@ class S3SourceListsTest(ShavarTestCase):
         # Basically the same tests in test_0_get_list and test_2_delta above
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
         for list_ in ('mozpub-track-digest256', 'testpub-bananas-digest256'):
-            sblist = get_list(dumdum, list_)
+            sblist, _ = get_list(dumdum, list_)
             self.assertIsInstance(sblist, Digest256)
             self.assertEqual(sblist.delta([1, 2], [3]), ([4, 5], [6]))
 

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -30,13 +30,11 @@ class ListsTest(ShavarTestCase):
 
     def test_2_get_list_list_not_served(self):
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
-        sblist = get_list(dumdum, 'this-list-dne')
         self.assertRaises(
             MissingListDataError, get_list, dumdum, 'this-list-dne'
         )
 
     def test_3_match_with_versioned_list_version_not_specified(self):
-        dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
         list_name = match_with_versioned_list(
             'none', ['70.0', '71.0'], 'mozpub-track-digest256')
         self.assertEquals(list_name, 'mozpub-track-digest256')

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -60,8 +60,8 @@ def shut_up_common_log_200s():
         """Drop HTTP 200s on the floor to minimize disk issues in prod."""
 
         def filter(self, record):
-            if ('code' in record.__dict__ and
-                    record.__dict__['code'] == 200):
+            if ('code' in record.__dict__
+                    and record.__dict__['code'] == 200):
                 return 0
             return 1
 

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -120,7 +120,7 @@ def downloads_view(request):
             raise HTTPBadRequest(s)
 
         app_ver = request.params.get('appver')
-        sblist, list_ver = get_list(request, list_info.name, app_ver)
+        sblist = get_list(request, list_info.name, app_ver)
 
         # Calculate delta
         to_add, to_sub = sblist.delta(list_info.adds, list_info.subs)
@@ -132,8 +132,7 @@ def downloads_view(request):
         # Fetch the appropriate chunks
         resp_payload['lists'][list_info.name] = {
             'sblist': sblist,
-            'ldata': sblist.fetch(to_add, to_sub),
-            'list_ver': list_ver
+            'ldata': sblist.fetch(to_add, to_sub)
         }
 
         # Not publishing deltas for this list?  Delete all previous chunks to
@@ -163,7 +162,6 @@ def format_downloads(request, resp_payload):
     for lname, ldict in resp_payload['lists'].iteritems():
         ldata = ldict['ldata']
         sblist = ldict['sblist']
-        list_ver = ldict['list_ver']
         # Support for the previous, broken method of responding to
         # digest256 type lists
         be_broken = sblist.settings.get(
@@ -194,11 +192,7 @@ def format_downloads(request, resp_payload):
                 baseurl = sblist.settings.get('redirect_url_base')
                 if not baseurl:
                     baseurl = _setting(request, 'shavar', 'redirect_url_base')
-                if list_ver is not None:
-                    fudge = os.path.join(
-                        baseurl, lname, list_ver, "%d" % chunk.number)
-                else:
-                    fudge = os.path.join(baseurl, lname, "%d" % chunk.number)
+                fudge = os.path.join(baseurl, lname, "%d" % chunk.number)
                 data = 'u:{0}\n'.format(fudge)
             body += data
     return body

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -120,7 +120,7 @@ def downloads_view(request):
             raise HTTPBadRequest(s)
 
         app_ver = request.params.get('appver')
-        sblist = get_list(request, list_info.name, app_ver)
+        sblist, list_ver = get_list(request, list_info.name, app_ver)
 
         # Calculate delta
         to_add, to_sub = sblist.delta(list_info.adds, list_info.subs)
@@ -132,7 +132,8 @@ def downloads_view(request):
         # Fetch the appropriate chunks
         resp_payload['lists'][list_info.name] = {
             'sblist': sblist,
-            'ldata': sblist.fetch(to_add, to_sub)
+            'ldata': sblist.fetch(to_add, to_sub),
+            'list_ver': list_ver
         }
 
         # Not publishing deltas for this list?  Delete all previous chunks to
@@ -162,6 +163,7 @@ def format_downloads(request, resp_payload):
     for lname, ldict in resp_payload['lists'].iteritems():
         ldata = ldict['ldata']
         sblist = ldict['sblist']
+        list_ver = ldict['list_ver']
         # Support for the previous, broken method of responding to
         # digest256 type lists
         be_broken = sblist.settings.get(
@@ -192,7 +194,11 @@ def format_downloads(request, resp_payload):
                 baseurl = sblist.settings.get('redirect_url_base')
                 if not baseurl:
                     baseurl = _setting(request, 'shavar', 'redirect_url_base')
-                fudge = os.path.join(baseurl, lname, "%d" % chunk.number)
+                if list_ver is not None:
+                    fudge = os.path.join(
+                        baseurl, lname, list_ver, "%d" % chunk.number)
+                else:
+                    fudge = os.path.join(baseurl, lname, "%d" % chunk.number)
                 data = 'u:{0}\n'.format(fudge)
             body += data
     return body

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -119,7 +119,8 @@ def downloads_view(request):
             annotate_request(request, "shavar.downloads.unknown.format", 1)
             raise HTTPBadRequest(s)
 
-        sblist = get_list(request, list_info.name)
+        app_ver = request.params.get('appver')
+        sblist = get_list(request, list_info.name, app_ver)
 
         # Calculate delta
         to_add, to_sub = sblist.delta(list_info.adds, list_info.subs)


### PR DESCRIPTION
# About this PR
Now that versioned lists are available in https://github.com/mozilla-services/shavar-list-creation/pull/92 this PR allows Firefox client to receive the versioned lists to enable testing of changes in the disconnect list as mentioned in https://github.com/mozilla-services/shavar-list-creation/issues/90.

# Acceptance Criteria
- [ ] If the version of the Firefox matches the supported version, the said versioned list is returned
- [ ] If the version of the Firefox matches fuzzily (truncate version from the end), the said versioned list is returned
- [ ] If the version of the Firefox is lower than `69.0`, versioned list using the `69.0` is returned
- [ ] If the version of the Firefox does not match the supported versions (e.g. version is higher than the existing versioned list) the list created from master is returned

# Test
### Setup the local environment
1. Add AWS credentials
```
export AWS_ACCESS_KEY_ID=<access_key>
export AWS_SECRET_ACCESS_KEY=<secret_key>
```
2. Include the `.ini` files of the lists you want to check for updates and download by adding them into `<project root>/shavar/tests/list_served`. For sample `.ini` file refer to [shavar-server-list-configs](https://github.com/mozilla-services/shavar-server-list-config)
3. Change the`source` and `redirect_url_base` in`.ini` to point to the S3 instance and cloudfront you want to use to test
### Check that the download returns the correct versioned download URL
1. Do the following cURL command `curl -d "social-tracking-protection-facebook-digest256;" "https://a3200d39.ngrok.io/downloads?appver=71.0`
Check that it returns the following response with the version stated in the URL
```
n:1800
i:social-tracking-protection-facebook-digest256
u:d1ynkhcfeddbte.cloudfront.net/social-tracking-protection-facebook-digest256/71.0/1570734441
```
2. Check that it is the same as the response from `curl -d "social-tracking-protection-facebook-digest256;" "https://shavar.services.mozilla.com/downloads?client=foo&appver=71.0a1&pver=2.2"`
```
n:3600
i:social-tracking-protection-facebook-digest256
u:tracking-protection.cdn.mozilla.net/social-tracking-protection-facebook-digest256/1564526481
```
3. Change the `appver` in the post URL to be lower than `69` and check that it still returns `69.0` like: `u:d1ynkhcfeddbte.cloudfront.net/social-tracking-protection-facebook-digest256/69.0/1570734441"`
4. Change the `appver` to be more specific like `71.0a1` and check that the download URL returns `71.0` like:
`u:d1ynkhcfeddbte.cloudfront.net/social-tracking-protection-facebook-digest256/71.0/1570734441`

#
~Dependent on https://github.com/mozilla-services/shavar-list-creation/pull/99~
Dependent on https://github.com/mozilla-services/shavar-server-list-config/pull/27