### PR TITLE
Signed get versions lists from S3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 boto==2.31.1
 konfig==0.9
 Paste==1.7.5.1
+packaging==19.2
 pastescript==2.0.2
 pyramid==1.9
 pyramid_chameleon==0.3
 pyramid_debugtoolbar==2.1
+requests==2.22.0
 raven==5.12.0
 statsd==3.0
 waitress==1.0.2

--- a/shavar/parse.py
+++ b/shavar/parse.py
@@ -108,8 +108,8 @@ def parse_gethash(request):
         prefix_len, payload_len = [int(x) for x in header.split(':', 1)]
     except ValueError:
         raise ParseError('Invalid prefix or payload size: "%s"' % header)
-    if ((payload_len % prefix_len != 0) or
-            (payload_len < prefix_len)):
+    if ((payload_len % prefix_len != 0)
+            or (payload_len < prefix_len)):
         raise ParseError("Payload length invalid: \"%d\"" % payload_len)
 
     prefix_total = payload_len / prefix_len
@@ -247,7 +247,7 @@ def parse_dir_source(handle, exists_cb=os.path.exists, open_cb=open):
         raise ParseError("Could not parse index file: %s" % e)
 
     if 'name' not in index:
-            raise ParseError("Incorrectly formatted index: missing list name")
+        raise ParseError("Incorrectly formatted index: missing list name")
 
     if 'chunks' not in index:
         raise ParseError("Incorrectly formatted index: missing chunks")

--- a/shavar/sources.py
+++ b/shavar/sources.py
@@ -32,7 +32,7 @@ class Source(object):
         self.no_data = True
 
     def load(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     def _populate_chunks(self, fp, parser_func, *args, **kwargs):
         try:
@@ -109,8 +109,8 @@ class DirectorySource(FileSource):
     index_name = 'index.json'
 
     def __init__(self, source_url, refresh_interval):
-        if (source_url[-1] == '/' or
-                source_url[-len(self.index_name):] != self.index_name):
+        if (source_url[-1] == '/'
+                or source_url[-len(self.index_name):] != self.index_name):
             source_url = posixpath.join(source_url, self.index_name)
 
         # Relative path to a directory, tweak slightly so urlparse will parse
@@ -180,8 +180,8 @@ class S3DirectorySource(S3FileSource):
     index_name = 'index.json'
 
     def __init__(self, source_url, refresh_interval):
-        if (source_url[-1] == '/' or
-                source_url[-len(self.index_name):] != self.index_name):
+        if (source_url[-1] == '/'
+                or source_url[-len(self.index_name):] != self.index_name):
             source_url = posixpath.join(source_url, self.index_name)
         super(S3DirectorySource, self).__init__(source_url,
                                                 refresh_interval)

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -5,7 +5,14 @@ import boto
 from boto.s3.key import Key
 from moto import mock_s3
 
-from shavar.lists import get_list, lookup_prefixes, Digest256
+from shavar.exceptions import MissingListDataError
+from shavar.lists import (
+    get_list,
+    lookup_prefixes,
+    Digest256,
+    match_with_versioned_list,
+    get_versioned_list_name
+)
 from shavar.tests.base import dummy, hashes, ShavarTestCase, test_file
 
 
@@ -20,6 +27,41 @@ class ListsTest(ShavarTestCase):
         dumdum = dummy(body='4:4\n%s' % hashes['goog'][:4], path='/gethash')
         prefixes = lookup_prefixes(dumdum, [self.hg[:4]])
         self.assertEqual(prefixes, {'moz-abp-shavar': {17: [hashes['goog']]}})
+
+    def test_2_get_list_list_not_served(self):
+        dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
+        self.assertRaises(
+            MissingListDataError, get_list, dumdum, 'this-list-dne'
+        )
+
+    def test_3_match_with_versioned_list_version_not_specified(self):
+        list_name = match_with_versioned_list(
+            'none', ['70.0', '71.0'], 'mozpub-track-digest256')
+        self.assertEquals(list_name, 'mozpub-track-digest256')
+
+    def test_4_match_with_versioned_list_version_lower_than_supported(self):
+        list_name = match_with_versioned_list(
+            '68.0', ['70.0', '71.0'], 'mozpub-track-digest256')
+        self.assertEquals(list_name, '69.0-mozpub-track-digest256')
+
+    def test_5_match_with_versioned_list_version_exact_match(self):
+        list_name = match_with_versioned_list(
+            '70.0', ['70.0', '71.0'], 'mozpub-track-digest256')
+        self.assertEquals(list_name, '70.0-mozpub-track-digest256')
+
+    def test_6_match_with_versioned_list_version_fuzzy_match(self):
+        list_name = match_with_versioned_list(
+            '71.0a1', ['70.0', '71.0'], 'mozpub-track-digest256')
+        self.assertEquals(list_name, '71.0-mozpub-track-digest256')
+
+    def test_7_match_with_versioned_list_version_fuzzy_match(self):
+        list_name = match_with_versioned_list(
+            '72.0a1', ['70.0', '71.0'], 'mozpub-track-digest256')
+        self.assertEquals(list_name, 'mozpub-track-digest256')
+
+    def test_8_get_versioned_list_name(self):
+        list_name = get_versioned_list_name('70.0', 'mozpub-track-digest256')
+        self.assertEquals(list_name, '70.0-mozpub-track-digest256')
 
 
 class DeltaListsTest(ShavarTestCase):

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -60,8 +60,8 @@ def shut_up_common_log_200s():
         """Drop HTTP 200s on the floor to minimize disk issues in prod."""
 
         def filter(self, record):
-            if ('code' in record.__dict__ and
-                    record.__dict__['code'] == 200):
+            if ('code' in record.__dict__
+                    and record.__dict__['code'] == 200):
                 return 0
             return 1
 
@@ -119,7 +119,8 @@ def downloads_view(request):
             annotate_request(request, "shavar.downloads.unknown.format", 1)
             raise HTTPBadRequest(s)
 
-        sblist = get_list(request, list_info.name)
+        app_ver = request.params.get('appver')
+        sblist = get_list(request, list_info.name, app_ver)
 
         # Calculate delta
         to_add, to_sub = sblist.delta(list_info.adds, list_info.subs)


### PR DESCRIPTION
# About this PR
Now that versioned lists are available in https://github.com/mozilla-services/shavar-list-creation/pull/92 this PR allows Firefox client to receive the versioned lists to enable testing of changes in the disconnect list as mentioned in https://github.com/mozilla-services/shavar-list-creation/issues/90.

# Acceptance Criteria
- [ ] If the version of the Firefox matches the supported version, the said versioned list is returned
- [ ] If the version of the Firefox matches fuzzily (truncate version from the end), the said versioned list is returned
- [ ] If the version of the Firefox is lower than `69.0`, versioned list using the `69.0` is returned
- [ ] If the version of the Firefox does not match the supported versions (e.g. version is higher than the existing versioned list) the list created from master is returned

# Test
### Setup the local environment
1. Add AWS credentials
```
export AWS_ACCESS_KEY_ID=<access_key>
export AWS_SECRET_ACCESS_KEY=<secret_key>
```
2. Include the `.ini` files of the lists you want to check for updates and download by adding them into `<project root>/shavar/tests/list_served`. For sample `.ini` file refer to [shavar-server-list-configs](https://github.com/mozilla-services/shavar-server-list-config)
3. Change the`source` and `redirect_url_base` in`.ini` to point to the S3 instance and cloudfront you want to use to test
### Check that the download returns the correct versioned download URL
1. Do the following cURL command `curl -d "social-tracking-protection-facebook-digest256;" "https://a3200d39.ngrok.io/downloads?appver=71.0`
Check that it returns the following response with the version stated in the URL
```
n:1800
i:social-tracking-protection-facebook-digest256
u:d1ynkhcfeddbte.cloudfront.net/social-tracking-protection-facebook-digest256/71.0/1570734441
```
2. Check that it is the same as the response from `curl -d "social-tracking-protection-facebook-digest256;" "https://shavar.services.mozilla.com/downloads?client=foo&appver=71.0a1&pver=2.2"`
```
n:3600
i:social-tracking-protection-facebook-digest256
u:tracking-protection.cdn.mozilla.net/social-tracking-protection-facebook-digest256/1564526481
```
3. Change the `appver` in the post URL to be lower than `69` and check that it still returns `69.0` like: `u:d1ynkhcfeddbte.cloudfront.net/social-tracking-protection-facebook-digest256/69.0/1570734441"`
4. Change the `appver` to be more specific like `71.0a1` and check that the download URL returns `71.0` like:
`u:d1ynkhcfeddbte.cloudfront.net/social-tracking-protection-facebook-digest256/71.0/1570734441`

#
~Dependent on https://github.com/mozilla-services/shavar-list-creation/pull/99~
Dependent on https://github.com/mozilla-services/shavar-server-list-config/pull/27

#
Closed #111 for the signed commits