### PR TITLE
Return versioned chunk num path

### DIFF
--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -158,16 +158,17 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
     ver = version.parse(app_version)
     # need to be wary of ESR, it's considered legacy version in packaging
     if not isinstance(ver, version.Version) or not supported_versions:
-        return list_name
+        return list_name, None
 
     default_ver = version.parse(OLDEST_SUPPORTED_VERSION)
     is_default_version = (
         ver.release and ver.release[0] <= default_ver.release[0])
     if is_default_version:
-        return get_versioned_list_name(default_ver.public, list_name)
+        return (get_versioned_list_name(default_ver.public, list_name),
+                default_ver.public)
 
     if ver.public in supported_versions:
-        return get_versioned_list_name(ver.public, list_name)
+        return get_versioned_list_name(ver.public, list_name), ver.public
 
     # truncate version to be less specific to lazy match
     truncate_ind = -1
@@ -175,11 +176,11 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
         if app_version[:truncate_ind] in supported_versions:
             versioned_list_name = get_versioned_list_name(
                 app_version[:truncate_ind], list_name)
-            return versioned_list_name
+            return versioned_list_name, app_version[:truncate_ind]
         truncate_ind -= 1
 
     # if none of the supported versions match, match with master
-    return list_name
+    return list_name, None
 
 
 def get_list(request, list_name, app_ver='none'):
@@ -187,10 +188,10 @@ def get_list(request, list_name, app_ver='none'):
         errmsg = 'Not serving requested list "%s"' % (list_name,)
         raise MissingListDataError(errmsg)
     all_supported_versions = request.registry['shavar.versioned_lists']
-    list_name = match_with_versioned_list(
+    list_name, list_ver = match_with_versioned_list(
         app_ver, all_supported_versions.get(list_name), list_name)
     registry_val = request.registry['shavar.serving'][list_name]
-    return registry_val
+    return registry_val, list_ver
 
 
 def lookup_prefixes(request, prefixes):

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -20,7 +20,7 @@ class ListsTest(ShavarTestCase):
 
     def test_0_get_list(self):
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
-        sblist = get_list(dumdum, 'mozpub-track-digest256')
+        sblist, _ = get_list(dumdum, 'mozpub-track-digest256')
         self.assertIsInstance(sblist, Digest256)
 
     def test_1_lookup_prefixes(self):
@@ -40,28 +40,45 @@ class ListsTest(ShavarTestCase):
         self.assertEquals(list_name, 'mozpub-track-digest256')
 
     def test_4_match_with_versioned_list_version_lower_than_supported(self):
-        list_name = match_with_versioned_list(
+        list_name, list_ver = match_with_versioned_list(
             '68.0', ['70.0', '71.0'], 'mozpub-track-digest256')
-        self.assertEquals(list_name, '69.0-mozpub-track-digest256')
+        self.assertEquals(
+            (list_name, list_ver),
+            ('69.0-mozpub-track-digest256', '69.0')
+        )
 
     def test_5_match_with_versioned_list_version_exact_match(self):
-        list_name = match_with_versioned_list(
+        list_name, list_ver = match_with_versioned_list(
             '70.0', ['70.0', '71.0'], 'mozpub-track-digest256')
-        self.assertEquals(list_name, '70.0-mozpub-track-digest256')
+        self.assertEquals(
+            (list_name, list_ver),
+            ('70.0-mozpub-track-digest256', '70.0')
+        )
 
     def test_6_match_with_versioned_list_version_fuzzy_match(self):
-        list_name = match_with_versioned_list(
+        list_name, list_ver = match_with_versioned_list(
             '71.0a1', ['70.0', '71.0'], 'mozpub-track-digest256')
-        self.assertEquals(list_name, '71.0-mozpub-track-digest256')
+        self.assertEquals(
+            (list_name, list_ver),
+            ('71.0-mozpub-track-digest256', '71.0')
+        )
 
     def test_7_match_with_versioned_list_version_fuzzy_match(self):
-        list_name = match_with_versioned_list(
+        list_name, list_ver = match_with_versioned_list(
             '72.0a1', ['70.0', '71.0'], 'mozpub-track-digest256')
-        self.assertEquals(list_name, 'mozpub-track-digest256')
+        self.assertEquals(
+            (list_name, list_ver),
+            ('mozpub-track-digest256', None)
+        )
 
     def test_8_get_versioned_list_name(self):
         list_name = get_versioned_list_name('70.0', 'mozpub-track-digest256')
         self.assertEquals(list_name, '70.0-mozpub-track-digest256')
+
+    def test_9_get_list_version_not_specified(self):
+        dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
+        sblist, list_ver = get_list(dumdum, 'mozpub-track-digest256')
+        self.assertIsNone(list_ver)
 
 
 class DeltaListsTest(ShavarTestCase):
@@ -70,7 +87,7 @@ class DeltaListsTest(ShavarTestCase):
 
     def test_2_delta(self):
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
-        sblist = get_list(dumdum, 'mozpub-track-digest256')
+        sblist, _ = get_list(dumdum, 'mozpub-track-digest256')
         # By way of explanation:
         #
         # In the data file.
@@ -141,7 +158,7 @@ class S3SourceListsTest(ShavarTestCase):
         # Basically the same tests in test_0_get_list and test_2_delta above
         dumdum = dummy(body='4:4\n%s' % self.hg[:4], path='/gethash')
         for list_ in ('mozpub-track-digest256', 'testpub-bananas-digest256'):
-            sblist = get_list(dumdum, list_)
+            sblist, _ = get_list(dumdum, list_)
             self.assertIsInstance(sblist, Digest256)
             self.assertEqual(sblist.delta([1, 2], [3]), ([4, 5], [6]))
 

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -35,9 +35,12 @@ class ListsTest(ShavarTestCase):
         )
 
     def test_3_match_with_versioned_list_version_not_specified(self):
-        list_name = match_with_versioned_list(
+        list_name, list_ver = match_with_versioned_list(
             'none', ['70.0', '71.0'], 'mozpub-track-digest256')
-        self.assertEquals(list_name, 'mozpub-track-digest256')
+        self.assertEquals(
+            (list_name, list_ver),
+            ('mozpub-track-digest256', None)
+        )
 
     def test_4_match_with_versioned_list_version_lower_than_supported(self):
         list_name, list_ver = match_with_versioned_list(


### PR DESCRIPTION
# About this PR
After pushing https://github.com/mozilla-services/shavar/pull/111 and testing we found the issue https://github.com/mozilla-services/shavar-list-creation/issues/106. This PR changes the `get_list` and `match_with_versioned_list` to return version number to return the path to versioned chunknum. Previously this code was first seen here https://github.com/mozilla-services/shavar/pull/111 under commits:
- 11b9dff
- 2af89a5
- acaefc3 

# Acceptance Criteria
- [ ] Does not break existing version functionality mentioned https://github.com/mozilla-services/shavar/pull/111
- [ ] Version value is used in the path for cloudfront download url returned in the response for `/downloads?app_ver=<ver>` if there is a match with a supported versioned

# Test
### Setup the local environment
1. Add AWS credentials
```
export AWS_ACCESS_KEY_ID=<access_key>
export AWS_SECRET_ACCESS_KEY=<secret_key>
```
2. Include the `.ini` files of the lists you want to check for updates and download by adding them into `<project root>/shavar/tests/list_served`. For sample `.ini` file refer to [shavar-server-list-configs](https://github.com/mozilla-services/shavar-server-list-config)
3. Change the`source` and `redirect_url_base` in`.ini` to point to the S3 instance and cloudfront you want to use to test
### Test that versions older than or equal to `69.0` returns the `69.0` version chunknum path
1. In your terminal execute `curl -d "base-fingerprinting-track-digest256;" 'http://localhost:6543/downloads?client=foo&appver=68.0&pver=2.2'`
2. Check that you get something like the following as a response:
```
n:1800
i:base-fingerprinting-track-digest256
u:<redirect_url_base>/base-fingerprinting-track-digest256/69.0/1572633681
```
`redirect_url_base` is mentioned in the `.ini` file of the list served mentioned in setup
### Test that version with exact match returns the matched version chunknum path
1. In your terminal execute `curl -d "base-fingerprinting-track-digest256;" 'http://localhost:6543/downloads?client=foo&appver=71.0&pver=2.2'`
2. Check that you get something like the following as a response:
```
n:1800
i:base-fingerprinting-track-digest256
u:<redirect_url_base>/base-fingerprinting-track-digest256/71.0/1572633681
```
### Test that version with fuzzy match returns the matched version chunknum path
1. In your terminal execute `curl -d "base-fingerprinting-track-digest256;" 'http://localhost:6543/downloads?client=foo&appver=71.0a1&pver=2.2'`
2. Check that you get something like the following as a response:
```
n:1800
i:base-fingerprinting-track-digest256
u:<redirect_url_base>/base-fingerprinting-track-digest256/71.0/1572633681
```
### Test that version newer than the supported version returns no version in the chunknum path
1. In your terminal execute `curl -d "base-fingerprinting-track-digest256;" 'http://localhost:6543/downloads?client=foo&appver=80.0&pver=2.2'`
2. Check that you get something like the following as a response:
```
n:1800
i:base-fingerprinting-track-digest256
u:<redirect_url_base>/base-fingerprinting-track-digest256/1572287413
```

**Note** the chunknum value, the digits in the end of the url mentioned in `u:` can vary based on which S3 you point your dev environment to.
