### PR TITLE
Add boto config for retrying

### DIFF
--- a/.boto
+++ b/.boto
@@ -1,0 +1,2 @@
+[Boto]
+metadata_service_num_attempts = 5

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -184,7 +184,8 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
 
 
 def get_list(request, list_name, app_ver='none'):
-    if list_name not in request.registry['shavar.serving']:
+    shavar_lists_served = request.registry['shavar.serving']
+    if list_name not in shavar_lists_served:
         errmsg = 'Not serving requested list "%s"' % (list_name,)
         raise MissingListDataError(errmsg)
     all_supported_versions = request.registry['shavar.versioned_lists']


### PR DESCRIPTION
# About this PR
After pushing changes on https://github.com/mozilla-services/shavar/pull/115 to production we rolled back due to latency not dropping as mentioned in [bugzilla here](https://bugzilla.mozilla.org/show_bug.cgi?id=1597531). We added additional hosts in 22:35 but latency returned as seen in the image below
![image (1)](https://user-images.githubusercontent.com/25109943/69279717-9b88c880-0baa-11ea-807c-aa0c9b72c388.png)
along with `NoAuthHandlerFound` error from boto and `MissingListDataError` popping up in Sentry. While attempting to replicate on local environment, when a thread gets the `NoAuthHandlerFound` error from boto the thread becomes unusable (returns 5xx) and hangs which could explain the increase of 5xx and latency when https://github.com/mozilla-services/shavar/pull/115 was deployed.
To fix this issue I referred to [this bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1006954) which indicates there is a race condition in boto where authentication fails while renewing.

# Acceptance Criteria
- [ ] `NoAuthHandlerFound` error no longer hapens
- [ ] Latency is decreased
- [ ] 5xx is decreased
- [ ] `MissingListDataError` error no longer happens (hypothesizing that `NoAuthHandlerFound` and the thread that becomes unusable is causing this error too)
