### PR TITLE
Fix MissingListDataError and return matched major version

### DIFF
--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -38,7 +38,9 @@ def get_versioned_list_name(version, list_name):
 
 
 def add_versioned_lists_to_registry(
-        settings, serving, ver_lists, type_, list_name, shavar_prod_lists_branches):
+        settings, serving, ver_lists, type_, list_name,
+        shavar_prod_lists_branches
+):
     for branch in shavar_prod_lists_branches:
         branch_name = branch.get('name')
         ver = version.parse(branch_name)

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -179,6 +179,12 @@ def match_with_versioned_list(app_version, supported_versions, list_name):
             return versioned_list_name, app_version[:truncate_ind]
         truncate_ind -= 1
 
+    # get the major version and match to that
+    major_ver = str(float(ver.release[0]))
+    if major_ver in supported_versions:
+        versioned_list_name = get_versioned_list_name(major_ver, list_name)
+        return versioned_list_name, major_ver
+
     # if none of the supported versions match, match with master
     return list_name, None
 

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -83,6 +83,14 @@ class ListsTest(ShavarTestCase):
         sblist, list_ver = get_list(dumdum, 'mozpub-track-digest256')
         self.assertIsNone(list_ver)
 
+    def test_10_match_with_versioned_list_major_version(self):
+        list_name, list_ver = match_with_versioned_list(
+            '71.1', ['70.0', '71.0'], 'mozpub-track-digest256')
+        self.assertEquals(
+            (list_name, list_ver),
+            ('71.0-mozpub-track-digest256', '71.0')
+        )
+
 
 class DeltaListsTest(ShavarTestCase):
 


### PR DESCRIPTION
# About this PR
The lazy match, which truncates the `app_ver` value sent via query param in the downloads request, does not check for the major version trailing with `.0`. https://github.com/mozilla-services/shavar/pull/120/commits/44df7b981a3f5ae8293508223ca5890d1b8f2675 in this PR fixes that.
Additionally, while testing for `NoAuthHandler` error mentioned in https://github.com/mozilla-services/shavar/pull/119 on Staging by making thousands of requests, we noted that `MissingListDataError` that was happening on [Production](https://sentry.prod.mozaws.net/operations/shavar-prod/issues/6665885/?query=is:unresolved) happening in [Staging](https://sentry.prod.mozaws.net/operations/shavar-stage/issues/6651487/?query=is:unresolved) without triggering the `NoAuthHandler` error on Staging. https://github.com/mozilla-services/shavar/pull/120/commits/f08456ecc4fd424f71f30dcf7fa49ee634e3e353 makes sure that the configuration being renewed happens immediately when the new list is ready rather than initializing to empty dictionary and waiting for the new lists to be populated.

# Acceptance Criteria
- [x] For requests with app versions not ending with `.0` but have major version supported (currently, `69`, `70`, `71`), the proper versioned list is returned
- [ ] `MissingListDataError` on [Production](https://sentry.prod.mozaws.net/operations/shavar-prod/issues/6665885/?query=is:unresolved) and on [Staging](https://sentry.prod.mozaws.net/operations/shavar-stage/issues/6651487/?query=is:unresolved) is resolved

# Practical Test
### Test that versions without `.0` but with major version support gets a versioned list to be downloaded
1. Do the following command in the console:
`curl -d "base-fingerprinting-track-digest256;" 'localhost:8080/downloads?client=foo&appver=70`
2. Check that in the response it returns `/70.0` in the redirect url mentioned in `u:`
### Test that versions with the minor version not ending with `.0` but major version support gets a versioned list to be downloaded
1. Do the following command in the console:
`curl -d "base-fingerprinting-track-digest256;" 'localhost:8080/downloads?client=foo&appver=70.6`
2. Check that in the response it returns `/70.0` in the redirect url mentioned in `u:`
### Check Staging Sentry that `MissingListDataError` is not happening when it gets thousands of requests