### PR TITLE
Get versioned entity lists

### DIFF
--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -45,9 +45,15 @@ def add_versioned_lists_to_registry(
         branch_name = branch.get('name')
         ver = version.parse(branch_name)
         if isinstance(ver, version.Version):
+            if 'entity/' in settings['source']:
+                original_path = 'entity/'
+                versioned_path = 'entity/{}/'
+            else:
+                original_path = 'tracking/'
+                versioned_path = 'tracking/{}/'
             # change config to reflect version branches
             versioned_source = settings['source'].replace(
-                'tracking/', 'tracking/{}/'.format(branch_name))
+                original_path, versioned_path.format(branch_name))
             settings['source'] = versioned_source
             # get new list for the version
             list_ = create_list(type_, list_name, settings)
@@ -57,7 +63,7 @@ def add_versioned_lists_to_registry(
             ver_lists[list_name].append(branch_name)
             # revert settings
             original_source = settings['source'].replace(
-                'tracking/{}/'.format(branch_name), 'tracking/')
+                versioned_path.format(branch_name), original_path)
             settings['source'] = original_source
 
 

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -37,6 +37,12 @@ def get_versioned_list_name(version, list_name):
     return '{0}-{1}'.format(version, list_name)
 
 
+def get_original_and_versioned_paths(source):
+    if 'entity/' in source:
+        return 'entity/', 'entity/{}/'
+    return 'tracking/', 'tracking/{}'
+
+
 def add_versioned_lists_to_registry(
         settings, serving, ver_lists, type_, list_name,
         shavar_prod_lists_branches
@@ -45,12 +51,9 @@ def add_versioned_lists_to_registry(
         branch_name = branch.get('name')
         ver = version.parse(branch_name)
         if isinstance(ver, version.Version):
-            if 'entity/' in settings['source']:
-                original_path = 'entity/'
-                versioned_path = 'entity/{}/'
-            else:
-                original_path = 'tracking/'
-                versioned_path = 'tracking/{}/'
+            original_path, versioned_path = get_original_and_versioned_paths(
+                settings['source']
+            )
             # change config to reflect version branches
             versioned_source = settings['source'].replace(
                 original_path, versioned_path.format(branch_name))


### PR DESCRIPTION
# About this PR
[Including all the regional Google domains](ttps://github.com/mozilla-services/shavar-prod-lists/pull/78) broke Shavar because it increased the entity list from ~300KB to 1.5MB. When creating the `mozstd-trackwhite-digest256`, remove the Google properties and resources and create a separate entity list google-trackwhite-digest256.

# Acceptance Criteria
- [ ] Version lower than the current Nightly (73) should return versioned mozstd-trackwhite-digest256. The entity list should still include Google domains, but not include regional changes in shavar-prod-lists as this will exceed the max size of the mozstd-trackwhite-digest256
- [ ] Version higher than or equal to the current Nightly should return mozstd-trackwhite-digest256 without the Google domains
- [ ] If the pref for Google entity lists is in Nightly (73), Shavar should also return google-trackwhite-digest256, entity list just Google domains

##
Dependent on https://github.com/mozilla-services/shavar-server-list-config/pull/29
Dependent on successful test on Staging and https://github.com/mozilla-services/shavar-server-list-config/pull/29 for Prod environment configuration