### PR TITLE
Remove support for not found list

### DIFF
--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -63,7 +63,10 @@ def add_versioned_lists_to_registry(
             try:
                 list_._source.load()
             except NoDataError:
-                # chunk file not found so it should not be served by Shavar
+                err_msg = ('Skipping {0} version support for {1} '
+                    'since the file does not exist in S3'
+                )
+                logger.error(err_msg.format(ver, list_name))
                 continue
             versioned_list_name = get_versioned_list_name(
                 branch_name, list_name)

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -63,7 +63,8 @@ def add_versioned_lists_to_registry(
             try:
                 list_._source.load()
             except NoDataError:
-                err_msg = ('Skipping {0} version support for {1} '
+                err_msg = (
+                    'Skipping {0} version support for {1} '
                     'since the file does not exist in S3'
                 )
                 logger.error(err_msg.format(ver, list_name))

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -60,6 +60,11 @@ def add_versioned_lists_to_registry(
             settings['source'] = versioned_source
             # get new list for the version
             list_ = create_list(type_, list_name, settings)
+            try:
+                list_._source.load()
+            except NoDataError, e:
+                # chunk file not found so it should not be served by Shavar
+                continue
             versioned_list_name = get_versioned_list_name(
                 branch_name, list_name)
             serving[versioned_list_name] = list_

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -62,7 +62,7 @@ def add_versioned_lists_to_registry(
             list_ = create_list(type_, list_name, settings)
             try:
                 list_._source.load()
-            except NoDataError, e:
+            except NoDataError:
                 # chunk file not found so it should not be served by Shavar
                 continue
             versioned_list_name = get_versioned_list_name(


### PR DESCRIPTION
# About this PR
While testing for #122 on Staging `'NoneType' object has no attribute 'etag'` events occurred for the first time ([logged in Sentry](https://sentry.prod.mozaws.net/operations/shavar-stage/issues/6895806/?query=is:unresolved)). Even after fixing the malformed versioned list path in #124, the event continued to occur. The error was reproducible if the versioned list was not found in the S3 but was under the served list by Shavar. This PR blocks versioned lists not found in the S3 to be listed as served in Shavar.

# Acceptance Criteria
- [ ]  blocks versioned lists not found in the S3 to be listed as served in Shavar

# Practical Tests
## Before getting the changes from the PR
### 1. Check that versioned lists not in S3 is listed as served
1. In your local S3 bucket for Shavar, remove a versioned list (e.g. delete the list in `tracking/72.0/base-fingerprinting-track-digest256` to delete the 72.0 versioned list for `base-fingerprinting-track-digest256`)
2. Run the command: `curl -d " " '127.0.0.1:8080/list?client=foo&appver=1&pver=2.2'`. Note `appver` and `pver` does not matter for this call
3. Check that the response still lists `72.0-base-fingerprinting-track-digest256` even though the 72.0 versioned `base-fingerprinting-track-digest256` does not exist in S3
### 2. Check that `/download` request for list not in S3 results in `'NoneType' object has no attribute 'etag'`
1. Run the command `curl -d "mozstd-trackwhite-digest256;" "127.0.0.1:8080/downloads?appver=72"`
2. On Shavar check that the application returns the following call stack:
```
...
  File "/usr/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 147, in _requestonly_view
    response = view(request)
  File "./shavar/views/__init__.py", line 126, in downloads_view
    to_add, to_sub = sblist.delta(list_info.adds, list_info.subs)
  File "./shavar/lists.py", line 305, in delta
    current_adds, current_subs = self._source.list_chunks()
  File "./shavar/sources.py", line 70, in list_chunks
    self.refresh()
  File "./shavar/sources.py", line 52, in refresh
    if self.needs_refresh():
  File "./shavar/sources.py", line 175, in needs_refresh
    if s3key.etag == self.current_etag:
AttributeError: 'NoneType' object has no attribute 'etag'
```
## After getting the changes from the PR
### 1. Check that versioned lists not in S3 is NOT listed as served
1. Run the command: `curl -d " " '127.0.0.1:8080/list?client=foo&appver=1&pver=2.2'`.
2. Check that the response does not list `72.0-base-fingerprinting-track-digest256`
### 2. Check that `/download` request for list not in S3 returns the fuzzy match of requested version
1. Run the command `curl -d "mozstd-trackwhite-digest256;" "127.0.0.1:8080/downloads?appver=72"`
2. Check that the response returns something like:
```
n:1800
i:mozstd-trackwhite-digest256
u:<cloudfront url>/mozstd-trackwhite-digest256/1576270325
```
Since 72 is the highest supported version it returns the list created from the master branch of `shavar-prod-lists` so the path is NOT versioned.