### PR TITLE
Revert the versioned source for lists to the original

### DIFF
--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -68,9 +68,9 @@ def add_versioned_lists_to_registry(
                     'since the file does not exist in S3'
                 )
                 logger.error(err_msg.format(ver, list_name))
-                original_source = settings['source'].replace(
-                    versioned_path.format(branch_name), original_path)
-                settings['source'] = original_source
+                # original_source = settings['source'].replace(
+                #     versioned_path.format(branch_name), original_path)
+                # settings['source'] = original_source
                 continue
             versioned_list_name = get_versioned_list_name(
                 branch_name, list_name)

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -68,6 +68,9 @@ def add_versioned_lists_to_registry(
                     'since the file does not exist in S3'
                 )
                 logger.error(err_msg.format(ver, list_name))
+                original_source = settings['source'].replace(
+                    versioned_path.format(branch_name), original_path)
+                settings['source'] = original_source
                 continue
             versioned_list_name = get_versioned_list_name(
                 branch_name, list_name)

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -68,9 +68,9 @@ def add_versioned_lists_to_registry(
                     'since the file does not exist in S3'
                 )
                 logger.error(err_msg.format(ver, list_name))
-                # original_source = settings['source'].replace(
-                #     versioned_path.format(branch_name), original_path)
-                # settings['source'] = original_source
+                original_source = settings['source'].replace(
+                    versioned_path.format(branch_name), original_path)
+                settings['source'] = original_source
                 continue
             versioned_list_name = get_versioned_list_name(
                 branch_name, list_name)

--- a/shavar/tests/lists_served/test-track-digest256.ini
+++ b/shavar/tests/lists_served/test-track-digest256.ini
@@ -1,0 +1,4 @@
+[test-track-digest256]
+type = digest256
+source = dir://shavar/tests/delta_dir_source
+redirect_url_base = http://localhost:6543/data/

--- a/shavar/tests/lists_served_s3/test-track-digest256.ini
+++ b/shavar/tests/lists_served_s3/test-track-digest256.ini
@@ -1,0 +1,4 @@
+[test-track-digest256]
+type = digest256
+source = s3+file://tracking/delta_chunk_source
+redirect_url_base = https://tracking.services.mozilla.com/

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -107,7 +107,6 @@ class AddVersionedListsTest(ShavarTestCase):
     dir_bucket_name = 'pickle-farthing'
     dir_list_name = 'test-track-digest256'
 
-
     def setUp(self):
         self.mock = mock_s3()
         self.mock.start()
@@ -202,8 +201,8 @@ class AddVersionedListsTest(ShavarTestCase):
         type_ = 'digest256'
         shavar_prod_lists_branches = [{'name': '69.0'}]
         add_versioned_lists_to_registry(
-                settings, serving, ver_lists, type_, list_name,
-                shavar_prod_lists_branches
+            settings, serving, ver_lists, type_, list_name,
+            shavar_prod_lists_branches
         )
         self.assertIn(list_name, serving)
         self.assertIn('69.0-' + list_name, serving)
@@ -225,8 +224,8 @@ class AddVersionedListsTest(ShavarTestCase):
         type_ = 'digest256'
         shavar_prod_lists_branches = [{'name': '68.0'}, {'name': '69.0'}]
         add_versioned_lists_to_registry(
-                settings, serving, ver_lists, type_, list_name,
-                shavar_prod_lists_branches
+            settings, serving, ver_lists, type_, list_name,
+            shavar_prod_lists_branches
         )
         self.assertIn(list_name, serving)
         self.assertIn('69.0-' + list_name, serving)

--- a/shavar/tests/test_lists.py
+++ b/shavar/tests/test_lists.py
@@ -8,6 +8,7 @@ from moto import mock_s3_deprecated as mock_s3
 
 from shavar.exceptions import MissingListDataError
 from shavar.lists import (
+    add_versioned_lists_to_registry,
     get_list,
     lookup_prefixes,
     Digest256,
@@ -91,6 +92,145 @@ class ListsTest(ShavarTestCase):
             (list_name, list_ver),
             ('71.0-mozpub-track-digest256', '71.0')
         )
+
+
+class AddVersionedListsTest(ShavarTestCase):
+
+    ini_file = "tests_s3.ini"
+
+    lists_served_bucket_name = 'shavar-lists-dev'
+    version_supported = '69.0'
+
+    bucket_name = 'tracking'
+    key_name = 'delta_chunk_source'
+
+    dir_bucket_name = 'pickle-farthing'
+    dir_list_name = 'test-track-digest256'
+
+
+    def setUp(self):
+        self.mock = mock_s3()
+        self.mock.start()
+
+        #
+        # Populate the data in mock S3
+        #
+        conn = boto.connect_s3()
+
+        # s3+dir lists_served bucket first
+        b = conn.create_bucket(self.lists_served_bucket_name)
+        for fname in ['test-track-digest256.ini',
+                      'testpub-bananas-digest256.ini']:
+            k = Key(b)
+            k.name = fname
+            f = open(os.path.join(
+                os.path.dirname(__file__), 'lists_served_s3', fname
+            ))
+            k.set_contents_from_file(f)
+
+        # s3+file contents
+        b = conn.create_bucket(self.bucket_name)
+        k = Key(b)
+        k.name = self.key_name
+        with open(test_file(self.key_name), 'rb') as f:
+            k.set_contents_from_file(f)
+        # add versioned file in s3+file bucket
+        k = Key(b)
+        k.name = '{}/{}'.format(self.version_supported, self.key_name)
+        with open(test_file(self.key_name), 'rb') as f:
+            k.set_contents_from_file(f)
+
+        # s3+dir keys and contents
+        b = conn.create_bucket(self.dir_bucket_name)
+        for fname in ('index.json', '1', '2', '3', '4', '5', '6'):
+            k = Key(b)
+            k.name = posixpath.join(self.dir_list_name, fname)
+            with open(test_file(posixpath.join('delta_dir_source', fname)),
+                      'rb') as f:
+                k.set_contents_from_file(f)
+        # add versioned file in s3+file bucket
+        for fname in ('index.json', '1', '2', '3', '4', '5', '6'):
+            k = Key(b)
+            k_name = posixpath.join(self.dir_list_name, fname)
+            k.name = '{}/{}'.format(self.version_supported, k_name)
+            with open(test_file(posixpath.join('delta_dir_source', fname)),
+                      'rb') as f:
+                k.set_contents_from_file(f)
+
+        responses.start()
+        GITHUB_API_URL = 'https://api.github.com'
+        SHAVAR_PROD_LISTS_BRANCHES_PATH = (
+            '/repos/mozilla-services/shavar-prod-lists/branches'
+        )
+        resp_body = """
+            [{
+              "name": "69.0",
+              "commit": {
+                "sha": "35665559e9e4a85c12bb8211b5f9217fbb96062d",
+                "url": "https://api.github.com/repos/mozilla-services/\
+                    shavar-prod-lists/commits/\
+                    35665559e9e4a85c12bb8211b5f9217fbb96062d"
+              }
+            }]
+        """
+        responses.add(
+            responses.GET, GITHUB_API_URL + SHAVAR_PROD_LISTS_BRANCHES_PATH,
+            body=resp_body
+        )
+        # initialize the internal list data structure via the normal method
+        super(AddVersionedListsTest, self).setUp()
+
+    def tearDown(self):
+        self.mock.stop()
+        responses.stop()
+        super(AddVersionedListsTest, self).tearDown()
+
+    def test_1_add_versioned_lists_to_registry(self):
+        list_name = 'test-track-digest256'
+        # sample settings from /tests/lists_served_s3/test-track-digest256
+        settings = {
+            'type': 'digest256',
+            'source': 's3+file://tracking/delta_chunk_source',
+            'redirect_url_base': 'https://tracking.services.mozilla.com/',
+        }
+        serving = {
+            list_name: dummy(body='').registry['shavar.serving'][list_name],
+        }
+        ver_lists = {
+            list_name: [],
+        }
+        type_ = 'digest256'
+        shavar_prod_lists_branches = [{'name': '69.0'}]
+        add_versioned_lists_to_registry(
+                settings, serving, ver_lists, type_, list_name,
+                shavar_prod_lists_branches
+        )
+        self.assertIn(list_name, serving)
+        self.assertIn('69.0-' + list_name, serving)
+
+    def test_2_add_versioned_lists_to_registry_does_not_exist(self):
+        list_name = 'test-track-digest256'
+        # sample settings from /tests/lists_served_s3/test-track-digest256
+        settings = {
+            'type': 'digest256',
+            'source': 's3+file://tracking/delta_chunk_source',
+            'redirect_url_base': 'https://tracking.services.mozilla.com/',
+        }
+        serving = {
+            list_name: dummy(body='').registry['shavar.serving'][list_name],
+        }
+        ver_lists = {
+            list_name: [],
+        }
+        type_ = 'digest256'
+        shavar_prod_lists_branches = [{'name': '68.0'}, {'name': '69.0'}]
+        add_versioned_lists_to_registry(
+                settings, serving, ver_lists, type_, list_name,
+                shavar_prod_lists_branches
+        )
+        self.assertIn(list_name, serving)
+        self.assertIn('69.0-' + list_name, serving)
+        self.assertNotIn('68.0-' + list_name, serving)
 
 
 class DeltaListsTest(ShavarTestCase):

--- a/shavar/tests/test_views.py
+++ b/shavar/tests/test_views.py
@@ -18,7 +18,7 @@ class ViewTests(ShavarTestCase):
         response = list_view(request)
         self.assertEqual(response.text,
                          "moz-abp-shavar\nmozpub-track-digest256\n"
-                         "testpub-bananas-digest256\n")
+                         "test-track-digest256\ntestpub-bananas-digest256\n")
 
     def test_3_newkey_view(self):
         # from shavar.views import newkey_view


### PR DESCRIPTION
# About this PR
Fix #144

# Acceptance Criteria
- [ ] When there is no file available in S3 for versioned list and another list is checked, the error message should not look like:
```
shavar.exceptions.NoDataError: No chunk file found at "s3+file://net-mozaws-prod-shavar/entity/74.0/73.0/72.0/71.0/70.0/69.0/google-trackwhite-digest256"
```
It should look like
```
shavar.exceptions.NoDataError: No chunk file found at "s3+file://net-mozaws-prod-shavar/entity/69.0/google-trackwhite-digest256"
```

# Practical Tests
Check that the same error message mentioned in A/C is shown when the versioned list does not exists
1. Comment out the [lines added](https://github.com/mozilla-services/shavar/pull/145/files#diff-f69e5e9f0be67b9ee6425c17d3bf1005R71-R73) in shavar/lists.py
2. Run tests for `AddVersionedListsTest` by running: `nosetests -s --nologcapture ./shavar/tests/test_lists.py:AddVersionedListsTest`
3. Check that the log looks like:
```
No index file found at "s3+dir://pickle-farthing/testpub-bananas-digest256/index.json"
.No index file found at "s3+dir://pickle-farthing/testpub-bananas-digest256/index.json"
No chunk file found at "s3+file://tracking/68.0/delta_chunk_source"
Skipping 68.0 version support for test-track-digest256 since the file does not exist in S3
No chunk file found at "s3+file://tracking/69.0/68.0/delta_chunk_source"
Skipping 69.0 version support for test-track-digest256 since the file does not exist in S3
F
======================================================================
FAIL: test_2_add_versioned_lists_to_registry_does_not_exist (shavar.tests.test_lists.AddVersionedListsTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sykim/shavar/shavar/tests/test_lists.py", line 232, in test_2_add_versioned_lists_to_registry_does_not_exist
    self.assertIn('69.0-' + list_name, serving)
AssertionError: '69.0-test-track-digest256' not found in {'test-track-digest256': <shavar.lists.Digest256 object at 0x10f230f50>}

----------------------------------------------------------------------
Ran 2 tests in 0.708s
```

Check that the fix applied on this PR prevents the incorrect source url to be used while getting the versioned list
1. Uncomment out the [lines added](https://github.com/mozilla-services/shavar/pull/145/files#diff-f69e5e9f0be67b9ee6425c17d3bf1005R71-R73) in shavar/lists.py
2. Run tests for `AddVersionedListsTest` by running: `nosetests -s --nologcapture ./shavar/tests/test_lists.py:AddVersionedListsTest`
3. Check that the log looks like:
```
No index file found at "s3+dir://pickle-farthing/testpub-bananas-digest256/index.json"
.No index file found at "s3+dir://pickle-farthing/testpub-bananas-digest256/index.json"
No chunk file found at "s3+file://tracking/68.0/delta_chunk_source"
Skipping 68.0 version support for test-track-digest256 since the file does not exist in S3
.
----------------------------------------------------------------------
Ran 2 tests in 0.891s

OK
```