### PR TITLE
Fill in the record.message

### DIFF
--- a/mozsvc/util.py
+++ b/mozsvc/util.py
@@ -141,6 +141,7 @@ class JsonLogFormatter(logging.Formatter):
         # Only include the 'message' key if it has useful content
         # and is not already a JSON blob.
         message = record.getMessage()
+        record.message = message
         if message:
             if not message.startswith("{") and not message.endswith("}"):
                 details["message"] = message


### PR DESCRIPTION
# About this PR
Sentry expects record.message field but our custom formatter, `JsonLogFormatter`, does not fill the record's message resulting in "Top level Sentry exception" logged in startup and refresh of Shavar. Fixes #146

# Acceptance Criteria
- [ ] "Top level Sentry exception" does not happen
- [ ]  NoDataError related logger.errors are logged properly

# Practical Tests
## Before applying the changes, check that the "Top level Sentry exception" is logged
1. Ping me for `shavar.ini` setup
2. Get Sentry account setup
3. Start Shavar and check that the following error is raised from `NoDataError` raised in `load()` call in `shavar/sources.py`
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/raven/handlers/logging.py", line 97, in emit
    return self._emit(record)
  File "/usr/local/lib/python3.7/site-packages/raven/handlers/logging.py", line 161, in _emit
    handler_kwargs[\'formatted\'] = text_type(record.message)
AttributeError: \'LogRecord\' object has no attribute \'message\''
```

## Apply the changes and check that the "Top level Sentry exception" is no longer logged and the NoDataErrors related errors are logged
1. Follow the previous test but with the changes in this PR. 