### PR TITLE
Reduce debug outputs

### DIFF
--- a/shavar.ini
+++ b/shavar.ini
@@ -24,6 +24,10 @@ threads = 2
 chdir = /app
 pythonpath = local/bin
 paste-logger = %p
+# hush 2xx logs
+disable-logging = True
+log-4xx = True
+log-5xx = True
 
 [loggers]
 keys = root


### PR DESCRIPTION
# About this PR
Reduce debug outputs with 2xx responses by using uWSGI flags.

# Acceptance Criteria
- [ ] Fix #138

# Practical Tests
## Check that the debug output does not suppress 2xx with the given `shavar.ini`
1. Run Shavar
2. Make a POST request to `/list` endpoint and check that the 200 log shows up
3. Make a POST request to `/lists` endpoint and check that the 404 log shows up

## Check that the debug output suppress 2xx when `stfu_200_logging` is set to `True`
1. Go to `shavar.ini` and under the section for `shavar` add the `stfu_200_logging = True`
2. Run Shavar
3. Make a POST request to `/list` endpoint and check that the 200 log DOES NOT show up
4. Make a POST request to `/lists` endpoint and check that the 404 log DOES show up

# Note to ckolos
@ckolos if you want to filter out the 2xx log messages you need to add the following code snippets into the `[uswgi]` section in the `.ini`
```
disable-logging = True
log-4xx = True
log-5xx = True
```
After doing so, if you set the `stfu_200_logging` into `True` 2xx logs should no longer appear on the console. 