### PR TITLE
Group invalid range events using Sentry fingerprint

### DIFF
--- a/shavar/__init__.py
+++ b/shavar/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import threading
 import time
 
@@ -53,12 +54,23 @@ def get_configurator(global_config, **settings):
     return config
 
 
+def group_errors(event, hint):
+    if 'logentry' in event and 'message' in event['logentry']:
+        message = event['logentry']['message']
+        pattern = 'Invalid RANGE "[0-9]{10}'
+        if re.match(pattern, message) is not None:
+            event['fingerprint'] = ['invalid-range']
+            return event
+    return event
+
+
 def configure_sentry(config):
     dsn = config.registry.settings.get('shavar.sentry_dsn')
     if dsn:
         sentry_sdk.init(
             dsn=dsn,
             integrations=[PyramidIntegration()],
+            before_send=group_errors
         )
 
 

--- a/shavar/__init__.py
+++ b/shavar/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import threading
 import time
 

--- a/shavar/__init__.py
+++ b/shavar/__init__.py
@@ -54,23 +54,12 @@ def get_configurator(global_config, **settings):
     return config
 
 
-def group_errors(event, hint):
-    if 'logentry' in event and 'message' in event['logentry']:
-        message = event['logentry']['message']
-        pattern = 'Invalid RANGE "[0-9]{10}'
-        if re.match(pattern, message) is not None:
-            event['fingerprint'] = ['invalid-range']
-            return event
-    return event
-
-
 def configure_sentry(config):
     dsn = config.registry.settings.get('shavar.sentry_dsn')
     if dsn:
         sentry_sdk.init(
             dsn=dsn,
-            integrations=[PyramidIntegration()],
-            before_send=group_errors
+            integrations=[PyramidIntegration()]
         )
 
 

--- a/shavar/views/__init__.py
+++ b/shavar/views/__init__.py
@@ -12,6 +12,7 @@ from pyramid.httpexceptions import (
     HTTPNotFound,
     HTTPInternalServerError)
 
+from sentry_sdk import capture_exception
 from shavar.exceptions import ConfigurationError, ParseError
 from shavar.lists import get_list, lookup_prefixes
 from shavar.parse import parse_downloads, parse_gethash
@@ -100,7 +101,7 @@ def downloads_view(request):
     try:
         parsed = parse_downloads(request)
     except ParseError as e:
-        logger.error(e)
+        capture_exception(e)
         raise HTTPBadRequest(e)
 
     for list_info in parsed:


### PR DESCRIPTION
# About this PR
After #149, we expected the update to `sentry_sdk` will fix #150. However, the events did not get grouped properly as the messages were unique and no stack trace were passed (no stack trace passed because the exception was not thrown and instead we caught logged the error). The changes here uses `before_send` to group the events using the `fingerprint` attribute of the sentry event.

# Acceptance Criteria
- [ ] Events have the "fingerprint" `invalid-range`
- [ ] Events are grouped using `invalid-range` fingerprint
- [ ] No new events are logged for the invalid range error if the event message looks like: `Invalid RANGE "<timestamp>-*`

# Practicals
## Check that the events have the fingerprint `invalid-range`
1. Execute the following command:
`curl -d "mozstd-trackwhite-digest256;a:9-3;" "localhost:8080/downloads?appver=76.0&pver=2.2"ps`
2. Check that an issue with error message `Invalid RANGE "9-3;" for mozstd-trackwhite-digest256` is logged on Sentry
3. Execute the following command:
`curl -d "mozstd-trackwhite-digest256;a:1234567890-3;" "localhost:8080/downloads?appver=76.0&pver=2.2"`
4. Check that issue is also logged in Sentry by increasing the event count AND NOT by creating a new event
5. Click on the event on Sentry
6. Click on the `JSON` link under the event ID
7. Check that under the `fingerprint` key `invalid-range` value exists.