### PR TITLE
Serve email trackers

### DIFF
--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -19,7 +19,7 @@ OLDEST_SUPPORTED_VERSION = '69.0'
 VERSION_EMAIL_CATEGORY_INTRODUCED = 97
 GITHUB_API_URL = 'https://api.github.com'
 SHAVAR_PROD_LISTS_BRANCHES_PATH = (
-    '/repos/mozilla-services/shavar-prod-lists/branches'
+    '/repos/mozilla-services/shavar-prod-lists/branches?per_page=100'
 )
 
 

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -17,6 +17,10 @@ from shavar.sources import (
 logger = logging.getLogger('shavar')
 OLDEST_SUPPORTED_VERSION = '69.0'
 VERSION_EMAIL_CATEGORY_INTRODUCED = 97
+EMAIL_TRACKER_LISTS = [
+    'base-email-track-digest256',
+    'content-email-track-digest256'
+]
 GITHUB_API_URL = 'https://api.github.com'
 SHAVAR_PROD_LISTS_BRANCHES_PATH = (
     '/repos/mozilla-services/shavar-prod-lists/branches?per_page=100'
@@ -52,7 +56,12 @@ def add_versioned_lists_to_registry(
         branch_name = branch.get('name')
         ver = version.parse(branch_name)
         if isinstance(ver, version.Version):
-            if type(ver.major) == int and ver.major < VERSION_EMAIL_CATEGORY_INTRODUCED:
+            skip_versioned_list = (
+                type(ver.major) == int
+                and ver.major < VERSION_EMAIL_CATEGORY_INTRODUCED
+                and list_name in EMAIL_TRACKER_LISTS
+            )
+            if skip_versioned_list:
                 continue
             original_path, versioned_path = get_original_and_versioned_paths(
                 settings['source']

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -16,6 +16,7 @@ from shavar.sources import (
 
 logger = logging.getLogger('shavar')
 OLDEST_SUPPORTED_VERSION = '69.0'
+VERSION_EMAIL_CATEGORY_INTRODUCED = 97
 GITHUB_API_URL = 'https://api.github.com'
 SHAVAR_PROD_LISTS_BRANCHES_PATH = (
     '/repos/mozilla-services/shavar-prod-lists/branches'
@@ -51,6 +52,8 @@ def add_versioned_lists_to_registry(
         branch_name = branch.get('name')
         ver = version.parse(branch_name)
         if isinstance(ver, version.Version):
+            if type(ver.major) == int and ver.major < VERSION_EMAIL_CATEGORY_INTRODUCED:
+                continue
             original_path, versioned_path = get_original_and_versioned_paths(
                 settings['source']
             )


### PR DESCRIPTION
# About this PR
`configparser.NoSectionError: No section: 'base-email-track-digest256'` was fixed by:

- adding the configurations for email trackers to be served by Shavar [here](https://github.com/mozilla-services/shavar-server-list-config/pull/33)
- skipping versioning for email tracker list if the version is older (lower) than `97` since the email categories were introduced in `97` and later (higher) versions.

This PR also fixes the previous issue with the GitHub API **not** returning the entire versioned list due to pagination in the request (same problem experienced and fixed in shavar-list-creation [here](https://github.com/mozilla-services/shavar-list-creation/pull/179)).
#
Changes are safe to go to Stage and Prod since
```python
list_name in EMAIL_TRACKER_LISTS
```
in shavar/lists.py will ALWAYS set `skip_versioned_list` to `False` on production since email tracker configurations are not in prod.ini of shavar-server-list-config.