### PR TITLE
Log and skip branch str when expecting dict

### DIFF
--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -53,7 +53,17 @@ def add_versioned_lists_to_registry(
         shavar_prod_lists_branches
 ):
     for branch in shavar_prod_lists_branches:
-        branch_name = branch.get('name')
+        try:
+            branch_name = branch.get('name')
+        except AttributeError as e:
+            logger.error(
+                'shavar_prod_lists_branches_error',
+                extra={
+                    'branch': branch,
+                    'error_message': e
+                }
+            )
+            continue
         ver = version.parse(branch_name)
         if isinstance(ver, version.Version):
             skip_versioned_list = (

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -60,7 +60,8 @@ def add_versioned_lists_to_registry(
                 'shavar_prod_lists_branches_error',
                 extra={
                     'branch': branch,
-                    'error_message': e
+                    'branches': shavar_prod_lists_branches,
+                    'error_message': e,
                 }
             )
             continue


### PR DESCRIPTION
# About this PR
The latest `Stage` keeps returning that the `branch` is a string when we are expecting a dictionary. This PR catches, handles, and logs the exception so that `Stage` can build successfully.