### PR TITLE
Remove duplicated skip logic

### DIFF
--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -67,13 +67,6 @@ def add_versioned_lists_to_registry(
             continue
         ver = version.parse(branch_name)
         if isinstance(ver, version.Version):
-            skip_versioned_list = (
-                type(ver.major) == int
-                and ver.major < VERSION_EMAIL_CATEGORY_INTRODUCED
-                and list_name in EMAIL_TRACKER_LISTS
-            )
-            if skip_versioned_list:
-                continue
             original_path, versioned_path = get_original_and_versioned_paths(
                 settings['source']
             )

--- a/shavar/lists.py
+++ b/shavar/lists.py
@@ -61,7 +61,7 @@ def add_versioned_lists_to_registry(
                 extra={
                     'branch': branch,
                     'branches': shavar_prod_lists_branches,
-                    'error_message': e,
+                    'error_message': e.__str__(),
                 }
             )
             continue


### PR DESCRIPTION
# About this PR
Removing duplicate code that skips if the email tracker versioned list does NOT exist which was already handled later in the code:
https://github.com/mozilla-services/shavar/blob/1faa18996a1b4082e446ed922744186c16435286/shavar/lists.py#L86-L97