### PR TITLE
Add Sentry IO configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Test
           command: |
-            docker run -d -p 8080:8080 -e SENTRY_DSN= --name shavar-test app:build START
+            docker run -d -p 8080:8080 -e SENTRY_DSN= -e SENTRY_ENV= --name shavar-test app:build START
             sleep 20
             docker exec shavar-test /bin/sh -c 'curl -d " " --retry 2 --retry-delay 2 --connect-timeout 10 -m 11 -v http://127.0.0.1:8080/list?client=foo&appver=1&pver=2.2'
       - run:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ A commented example configuration:
     # are not provided in the list specific stanzas.  Not necessary if you
     # provide absolute paths.
     lists_root = tests
+    sentry_dsn = ""
+    # The DSN from the "Client Keys" section in the project settings in Sentry
+    sentry_env = ""
+    # The environment to use for sentry, e.g. dev, stage, or prod
 
     # This is the public host and scheme to reach the service
     # like https://shavar.stage.mozaws.net

--- a/shavar.ini
+++ b/shavar.ini
@@ -58,3 +58,4 @@ default_proto_ver = 2.0
 lists_served = dir://shavar/tests/lists_served
 lists_root = tests
 sentry_dsn = ${SENTRY_DSN}
+sentry_env = ${SENTRY_ENV}

--- a/shavar/__init__.py
+++ b/shavar/__init__.py
@@ -61,7 +61,8 @@ def configure_sentry(config):
             env_option = {"environment": SENTRY_ENV}
         sentry_sdk.init(
             dsn=dsn,
-            integrations=[PyramidIntegration(), **env_option]
+            integrations=[PyramidIntegration()],
+            **env_option
         )
 
 

--- a/shavar/__init__.py
+++ b/shavar/__init__.py
@@ -55,10 +55,11 @@ def get_configurator(global_config, **settings):
 
 def configure_sentry(config):
     dsn = config.registry.settings.get('shavar.sentry_dsn')
+    sentry_env = config.registry.settings.get('shavar.sentry_env')
     if dsn:
         env_option = {}
-        if SENTRY_ENV:
-            env_option = {"environment": SENTRY_ENV}
+        if sentry_env:
+            env_option = {"environment": sentry_env}
         sentry_sdk.init(
             dsn=dsn,
             integrations=[PyramidIntegration()],

--- a/shavar/__init__.py
+++ b/shavar/__init__.py
@@ -56,9 +56,12 @@ def get_configurator(global_config, **settings):
 def configure_sentry(config):
     dsn = config.registry.settings.get('shavar.sentry_dsn')
     if dsn:
+        env_option = {}
+        if SENTRY_ENV:
+            env_option = {"environment": SENTRY_ENV}
         sentry_sdk.init(
             dsn=dsn,
-            integrations=[PyramidIntegration()]
+            integrations=[PyramidIntegration(), **env_option]
         )
 
 


### PR DESCRIPTION
To move from Sentry to Sentry IO, we need to add some new configurations `sentry_dsn` and `sentry_env`.

# New variables introduced
## Sentry DSN
[Configurations doc](https://docs.sentry.io/platforms/python/configuration/options/#dsn). Variable used by the Sentry SDK that tells where to send the events.
## Sentry Environment
[Configurations doc](https://docs.sentry.io/platforms/python/configuration/options/#environment). Variable used by Sentry IO to associate release/environment for cleaner Sentry project management.